### PR TITLE
Bugfix topic reduction

### DIFF
--- a/bertopic/__init__.py
+++ b/bertopic/__init__.py
@@ -1,2 +1,2 @@
 from bertopic.model import BERTopic
-__version__ = "0.2.1"
+__version__ = "0.3.2"

--- a/bertopic/model.py
+++ b/bertopic/model.py
@@ -154,8 +154,7 @@ class BERTopic:
 
     def fit_transform(self,
                       documents: List[str],
-                      embeddings: np.ndarray = None) -> Tuple[List[int],
-                                                              np.ndarray]:
+                      embeddings: np.ndarray = None):
         """ Fit the models on a collection of documents, generate topics, and return the docs with topics
 
         Arguments:
@@ -221,7 +220,7 @@ class BERTopic:
 
         predictions = documents.Topic.to_list()
 
-        return predictions, probabilities
+        return predictions, probabilities, c_tf_idf, documents
 
     def transform(self,
                   documents: Union[str, List[str]],

--- a/bertopic/model.py
+++ b/bertopic/model.py
@@ -494,7 +494,7 @@ class BERTopic:
 
             # Update new topic content
             self._update_topic_size(documents)
-            self._extract_topics(documents, topic_reduction=True)
+            c_tf_idf = self._extract_topics(documents, topic_reduction=True)
 
         if initial_nr_topics <= self.nr_topics:
             logger.info(f"Since {initial_nr_topics} were found, they could not be reduced to {self.nr_topics}")

--- a/bertopic/model.py
+++ b/bertopic/model.py
@@ -479,11 +479,11 @@ class BERTopic:
         self.mapped_topics = {}
         initial_nr_topics = len(self.get_topics())
 
-        while len(self.get_topics()) > self.nr_topics:
-            # Create topic similarity matrix
-            similarities = cosine_similarity(c_tf_idf)
-            np.fill_diagonal(similarities, 0)
+        # Create topic similarity matrix
+        similarities = cosine_similarity(c_tf_idf)
+        np.fill_diagonal(similarities, 0)
 
+        while len(self.get_topics()) > self.nr_topics:
             # Find most similar topic to least common topic
             topic_to_merge = self.get_topics_freq().iloc[-1].Topic
             topic_to_merge_into = np.argmax(similarities[topic_to_merge + 1]) - 1
@@ -494,7 +494,7 @@ class BERTopic:
 
             # Update new topic content
             self._update_topic_size(documents)
-            c_tf_idf = self._extract_topics(documents, topic_reduction=True)
+            self._extract_topics(documents, topic_reduction=True)
 
         if initial_nr_topics <= self.nr_topics:
             logger.info(f"Since {initial_nr_topics} were found, they could not be reduced to {self.nr_topics}")

--- a/bertopic/model.py
+++ b/bertopic/model.py
@@ -154,7 +154,8 @@ class BERTopic:
 
     def fit_transform(self,
                       documents: List[str],
-                      embeddings: np.ndarray = None):
+                      embeddings: np.ndarray = None) -> Tuple[List[int],
+                                                              np.ndarray]:
         """ Fit the models on a collection of documents, generate topics, and return the docs with topics
 
         Arguments:
@@ -220,7 +221,7 @@ class BERTopic:
 
         predictions = documents.Topic.to_list()
 
-        return predictions, probabilities, c_tf_idf, documents
+        return predictions, probabilities
 
     def transform(self,
                   documents: Union[str, List[str]],
@@ -477,9 +478,8 @@ class BERTopic:
         """
         self.mapped_topics = {}
         initial_nr_topics = len(self.get_topics())
-        nr_to_reduce = initial_nr_topics - self.nr_topics
 
-        for _ in range(nr_to_reduce):
+        while len(self.get_topics()) > self.nr_topics:
             # Create topic similarity matrix
             similarities = cosine_similarity(c_tf_idf)
             np.fill_diagonal(similarities, 0)

--- a/bertopic/model.py
+++ b/bertopic/model.py
@@ -483,7 +483,7 @@ class BERTopic:
         similarities = cosine_similarity(c_tf_idf)
         np.fill_diagonal(similarities, 0)
 
-        while len(self.get_topics()) > self.nr_topics:
+        while len(self.get_topics()) > self.nr_topics + 1:
             # Find most similar topic to least common topic
             topic_to_merge = self.get_topics_freq().iloc[-1].Topic
             topic_to_merge_into = np.argmax(similarities[topic_to_merge + 1]) - 1

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="bertopic",
     packages=["bertopic"],
-    version="0.3.1",
+    version="0.3.2",
     author="Maarten Grootendorst",
     author_email="maartengrootendorst@gmail.com",
     description="BERTopic performs topic Modeling with state-of-the-art transformer models.",


### PR DESCRIPTION
There is a bug with the topic reduction method that seems to reduce the number of topics but not to the `nr_topics`  as defined in the class (#14). It appears to stem from the moment topics are mapped to one another. It might happen that when three topics are mapped to each other it creates a linked mapping and does not reduce the number of topics. This is easily fixed by using a while loop instead of a for loop. 