### PR TITLE
Add custom countvectorizer parameter

### DIFF
--- a/bertopic/__init__.py
+++ b/bertopic/__init__.py
@@ -1,2 +1,2 @@
 from bertopic.model import BERTopic
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/bertopic/model.py
+++ b/bertopic/model.py
@@ -39,14 +39,17 @@ class BERTopic:
         n_gram_range: The n-gram range for the CountVectorizer.
                       Advised to keep high values between 1 and 3.
                       More would likely lead to memory issues.
+                      Note that this will not be used if you pass in your own CountVectorizer.
         min_topic_size: The minimum size of the topic.
         n_neighbors: The size of local neighborhood (in terms of number of neighboring sample points) used
                      for manifold approximation (UMAP).
         n_components: The dimension of the space to embed into when reducing dimensionality with UMAP.
         stop_words: Stopwords that can be used as either a list of strings, or the name of the
                     language as a string. For example: 'english' or ['the', 'and', 'I'].
+                    Note that this will not be used if you pass in your own CountVectorizer.
         verbose: Changes the verbosity of the model, Set to True if you want
                  to track the stages of the model.
+        vectorizer: Pass in your own CountVectorizer from scikit-learn
 
     Usage:
 
@@ -91,7 +94,8 @@ class BERTopic:
                  n_neighbors: int = 15,
                  n_components: int = 5,
                  stop_words: Union[str, List[str]] = None,
-                 verbose: bool = False):
+                 verbose: bool = False,
+                 vectorizer: CountVectorizer = None):
         self.bert_model = bert_model
         self.top_n_words = top_n_words
         self.nr_topics = nr_topics
@@ -100,6 +104,7 @@ class BERTopic:
         self.n_neighbors = n_neighbors
         self.n_components = n_components
         self.stop_words = stop_words
+        self.vectorizer = vectorizer or CountVectorizer(ngram_range=self.n_gram_range, stop_words=self.stop_words)
 
         self.umap_model = None
         self.cluster_model = None
@@ -387,7 +392,7 @@ class BERTopic:
             words: The names of the words to which values were given
         """
         documents = documents_per_topic.Document.values
-        count = CountVectorizer(ngram_range=self.n_gram_range, stop_words=self.stop_words).fit(documents)
+        count = self.vectorizer.fit(documents)
         words = count.get_feature_names()
         X = count.transform(documents)
         transformer = ClassTFIDF().fit(X, n_samples=m)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="bertopic",
     packages=["bertopic"],
-    version="0.3.3",
+    version="0.3.4",
     author="Maarten Grootendorst",
     author_email="maartengrootendorst@gmail.com",
     description="BERTopic performs topic Modeling with state-of-the-art transformer models.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from sklearn.feature_extraction.text import CountVectorizer
 from bertopic import BERTopic
 import pytest
 
@@ -12,4 +13,18 @@ def base_bertopic():
                      n_neighbors=15,
                      n_components=5,
                      verbose=False)
+    return model
+
+
+@pytest.fixture(scope="module")
+def base_bertopic_custom_cv():
+    cv = CountVectorizer(ngram_range=(1, 2))
+    model = BERTopic(bert_model='distilbert-base-nli-mean-tokens',
+                     top_n_words=20,
+                     nr_topics=None,
+                     min_topic_size=30,
+                     n_neighbors=15,
+                     n_components=5,
+                     verbose=False,
+                     vectorizer=cv)
     return model

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -80,6 +80,26 @@ def test_extract_topics(base_bertopic):
     assert len(freq.Topic.unique()) == len(freq)
 
 
+def test_extract_topics_custom_cv(base_bertopic_custom_cv):
+    """ Test whether the topics are correctly extracted using c-TF-IDF
+    with custom CountVectorizer
+    """
+    nr_topics = 5
+    documents = pd.DataFrame({"Document": newsgroup_docs,
+                              "ID": range(len(newsgroup_docs)),
+                              "Topic": np.random.randint(-1, nr_topics-1, len(newsgroup_docs))})
+    base_bertopic_custom_cv._update_topic_size(documents)
+    c_tf_idf = base_bertopic_custom_cv._extract_topics(documents, topic_reduction=False)
+    freq = base_bertopic_custom_cv.get_topics_freq()
+
+    assert c_tf_idf.shape[0] == 5
+    assert c_tf_idf.shape[1] > 100
+    assert isinstance(freq, pd.DataFrame)
+    assert nr_topics == len(freq.Topic.unique())
+    assert freq.Count.sum() == len(documents)
+    assert len(freq.Topic.unique()) == len(freq)
+
+
 @pytest.mark.parametrize("reduced_topics", [5, 10, 20, 40])
 def test_topic_reduction(reduced_topics):
     """ Test whether the topics are correctly reduced """


### PR DESCRIPTION
Provide the ability to pass a custom countvectorizer to BERTopic (#18):

```python
from sklearn.feature_extraction.text import CountVectorizer
from bertopic import BERTopic

cv = CountVectorizer(ngram_range=(1, 2))
model = BERTopic(bert_model='distilbert-base-nli-mean-tokens', vectorizer=cv)
```


