### PR TITLE
Limit plotly version

### DIFF
--- a/bertopic/__init__.py
+++ b/bertopic/__init__.py
@@ -2,7 +2,7 @@ from bertopic._bertopic import BERTopic
 from bertopic._ctfidf import ClassTFIDF
 from bertopic._embeddings import languages
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 __all__ = [
     "BERTopic",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ base_packages = [
 
 visualization_packages = [
     "matplotlib>=3.2.2",
-    "plotly>=4.7.0"
+    "plotly>=4.7.0,<4.14.3"
 ]
 
 dev_packages = docs_packages + test_packages + visualization_packages
@@ -39,7 +39,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="bertopic",
     packages=["bertopic"],
-    version="0.4.2",
+    version="0.4.3",
     author="Maarten Grootendorst",
     author_email="maartengrootendorst@gmail.com",
     description="BERTopic performs topic Modeling with state-of-the-art transformer models.",


### PR DESCRIPTION
Plotly v4.14.3 causes problems with `hover_data` not correctly showing the topic words and sizes (#39). As a quick fix, limit the plotly version in setup.py. 