### PR TITLE
Fix hovertemplate indices for LDAviz-like plotting

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -1471,8 +1471,8 @@ class BERTopic:
 
         # Update hover order
         fig.update_traces(hovertemplate="<br>".join(["<b>Topic %{customdata[2]}</b>",
-                                                     "Words: %{customdata[3]}",
-                                                     "Size: %{customdata[4]}"]))
+                                                     "Words: %{customdata[1]}",
+                                                     "Size: %{customdata[0]}"]))
 
         # Create a slider for topic selection
         steps = [dict(label=f"Topic {topic}", method="update", args=get_color(topic)) for topic in topic_list[1:]]

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -739,7 +739,7 @@ class BERTopic:
 
         return new_topics, new_probabilities
 
-    def visualize_topics(self):
+    def visualize_topics(self, plot_size=960):
         """ Visualize topics, their sizes, and their corresponding words
 
         This visualization is highly inspired by LDAvis, a great visualization
@@ -777,7 +777,7 @@ class BERTopic:
         # Visualize with plotly
         df = pd.DataFrame({"x": embeddings[1:, 0], "y": embeddings[1:, 1],
                            "Topic": topic_list[1:], "Words": words[1:], "Size": frequencies[1:]})
-        return self._plotly_topic_visualization(df, topic_list)
+        return self._plotly_topic_visualization(df, topic_list, plot_size)
 
     def visualize_topics_over_time(self,
                                    topics_over_time: pd.DataFrame,
@@ -1450,7 +1450,8 @@ class BERTopic:
 
     @staticmethod
     def _plotly_topic_visualization(df: pd.DataFrame,
-                                    topic_list: List[str]):
+                                    topic_list: List[str],
+                                    plot_size: int):
         """ Create plotly-based visualization of topics with a slider for topic selection """
 
         def get_color(topic_selected):
@@ -1490,8 +1491,8 @@ class BERTopic:
                     size=22,
                     color="Black")
             },
-            width=650,
-            height=650,
+            width=plot_size,
+            height=plot_size,
             hoverlabel=dict(
                 bgcolor="white",
                 font_size=16,


### PR DESCRIPTION
I had to swap these indices around in order to get "Words: " and "Size: " data to appear in my plots.