### PR TITLE
Update SentenceTransformers model

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ You can select any model from sentence-transformers [here](https://www.sbert.net
 and pass it to BERTopic:
 
 ```python
-topic_model = BERTopic(embedding_model="paraphrase-mpnet-base-v2")
+topic_model = BERTopic(embedding_model="paraphrase-MiniLM-L6-v22")
 ```
 
 Or select a SentenceTransformer model with your own parameters:
@@ -139,7 +139,7 @@ Or select a SentenceTransformer model with your own parameters:
 ```python
 from sentence_transformers import SentenceTransformer
 
-sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
+sentence_model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
 topic_model = BERTopic(embedding_model=sentence_model)
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ You can select any model from sentence-transformers [here](https://www.sbert.net
 and pass it to BERTopic:
 
 ```python
-topic_model = BERTopic(embedding_model="xlm-r-bert-base-nli-stsb-mean-tokens")
+topic_model = BERTopic(embedding_model="paraphrase-mpnet-base-v2")
 ```
 
 Or select a SentenceTransformer model with your own parameters:
@@ -139,7 +139,7 @@ Or select a SentenceTransformer model with your own parameters:
 ```python
 from sentence_transformers import SentenceTransformer
 
-sentence_model = SentenceTransformer("distilbert-base-nli-mean-tokens", device="cpu")
+sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
 topic_model = BERTopic(embedding_model=sentence_model)
 ```
 

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -55,7 +55,7 @@ class BERTopic:
     from sentence_transformers import SentenceTransformer
 
     docs = fetch_20newsgroups(subset='all')['data']
-    sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
+    sentence_model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
     topic_model = BERTopic(embedding_model=sentence_model)
     ```
 
@@ -196,7 +196,7 @@ class BERTopic:
 
         # Create embeddings
         docs = fetch_20newsgroups(subset='all')['data']
-        sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
+        sentence_model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
         embeddings = sentence_model.encode(docs, show_progress_bar=True)
 
         # Create topic model
@@ -247,7 +247,7 @@ class BERTopic:
 
         # Create embeddings
         docs = fetch_20newsgroups(subset='all')['data']
-        sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
+        sentence_model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
         embeddings = sentence_model.encode(docs, show_progress_bar=True)
 
         # Create topic model
@@ -333,7 +333,7 @@ class BERTopic:
 
         # Create embeddings
         docs = fetch_20newsgroups(subset='all')['data']
-        sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
+        sentence_model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
         embeddings = sentence_model.encode(docs, show_progress_bar=True)
 
         # Create topic model

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -55,7 +55,7 @@ class BERTopic:
     from sentence_transformers import SentenceTransformer
 
     docs = fetch_20newsgroups(subset='all')['data']
-    sentence_model = SentenceTransformer("distilbert-base-nli-mean-tokens")
+    sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
     topic_model = BERTopic(embedding_model=sentence_model)
     ```
 
@@ -196,7 +196,7 @@ class BERTopic:
 
         # Create embeddings
         docs = fetch_20newsgroups(subset='all')['data']
-        sentence_model = SentenceTransformer("distilbert-base-nli-mean-tokens")
+        sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
         embeddings = sentence_model.encode(docs, show_progress_bar=True)
 
         # Create topic model
@@ -247,7 +247,7 @@ class BERTopic:
 
         # Create embeddings
         docs = fetch_20newsgroups(subset='all')['data']
-        sentence_model = SentenceTransformer("distilbert-base-nli-mean-tokens")
+        sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
         embeddings = sentence_model.encode(docs, show_progress_bar=True)
 
         # Create topic model
@@ -333,7 +333,7 @@ class BERTopic:
 
         # Create embeddings
         docs = fetch_20newsgroups(subset='all')['data']
-        sentence_model = SentenceTransformer("distilbert-base-nli-mean-tokens")
+        sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
         embeddings = sentence_model.encode(docs, show_progress_bar=True)
 
         # Create topic model

--- a/bertopic/backend/_sentencetransformers.py
+++ b/bertopic/backend/_sentencetransformers.py
@@ -22,7 +22,7 @@ class SentenceTransformerBackend(BaseEmbedder):
     ```python
     from bertopic.backend import SentenceTransformerBackend
 
-    sentence_model = SentenceTransformerBackend("paraphrase-mpnet-base-v2")
+    sentence_model = SentenceTransformerBackend("paraphrase-MiniLM-L6-v2")
     ```
 
     or  you can instantiate a model yourself:
@@ -30,7 +30,7 @@ class SentenceTransformerBackend(BaseEmbedder):
     from bertopic.backend import SentenceTransformerBackend
     from sentence_transformers import SentenceTransformer
 
-    embedding_model = SentenceTransformer("paraphrase-mpnet-base-v2")
+    embedding_model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
     sentence_model = SentenceTransformerBackend(embedding_model)
     ```
     """
@@ -44,7 +44,7 @@ class SentenceTransformerBackend(BaseEmbedder):
         else:
             raise ValueError("Please select a correct SentenceTransformers model: \n"
                              "`from sentence_transformers import SentenceTransformer` \n"
-                             "`model = SentenceTransformer('paraphrase-mpnet-base-v2')`")
+                             "`model = SentenceTransformer('paraphrase-MiniLM-L6-v2')`")
 
     def embed(self,
               documents: List[str],

--- a/bertopic/backend/_sentencetransformers.py
+++ b/bertopic/backend/_sentencetransformers.py
@@ -22,7 +22,7 @@ class SentenceTransformerBackend(BaseEmbedder):
     ```python
     from bertopic.backend import SentenceTransformerBackend
 
-    sentence_model = SentenceTransformerBackend("distilbert-base-nli-stsb-mean-tokens")
+    sentence_model = SentenceTransformerBackend("paraphrase-mpnet-base-v2")
     ```
 
     or  you can instantiate a model yourself:
@@ -30,7 +30,7 @@ class SentenceTransformerBackend(BaseEmbedder):
     from bertopic.backend import SentenceTransformerBackend
     from sentence_transformers import SentenceTransformer
 
-    embedding_model = SentenceTransformer("distilbert-base-nli-stsb-mean-tokens")
+    embedding_model = SentenceTransformer("paraphrase-mpnet-base-v2")
     sentence_model = SentenceTransformerBackend(embedding_model)
     ```
     """
@@ -44,7 +44,7 @@ class SentenceTransformerBackend(BaseEmbedder):
         else:
             raise ValueError("Please select a correct SentenceTransformers model: \n"
                              "`from sentence_transformers import SentenceTransformer` \n"
-                             "`model = SentenceTransformer('distilbert-base-nli-stsb-mean-tokens')`")
+                             "`model = SentenceTransformer('paraphrase-mpnet-base-v2')`")
 
     def embed(self,
               documents: List[str],

--- a/bertopic/backend/_utils.py
+++ b/bertopic/backend/_utils.py
@@ -21,8 +21,8 @@ languages = ['afrikaans', 'albanian', 'amharic', 'arabic', 'armenian', 'assamese
 def select_backend(embedding_model,
                    language: str = None) -> BaseEmbedder:
     """ Select an embedding model based on language or a specific sentence transformer models.
-    When selecting a language, we choose distilbert-base-nli-stsb-mean-tokens for English and
-    xlm-r-bert-base-nli-stsb-mean-tokens for all other languages as it support 100+ languages.
+    When selecting a language, we choose paraphrase-mpnet-base-v2 for English and
+    paraphrase-multilingual-mpnet-base-v2 for all other languages as it support 100+ languages.
 
     Returns:
         model: Either a Sentence-Transformer or Flair model
@@ -62,13 +62,13 @@ def select_backend(embedding_model,
     # Select embedding model based on language
     if language:
         if language.lower() in ["English", "english", "en"]:
-            return SentenceTransformerBackend("distilbert-base-nli-stsb-mean-tokens")
+            return SentenceTransformerBackend("paraphrase-mpnet-base-v2")
         elif language.lower() in languages or language == "multilingual":
-            return SentenceTransformerBackend("xlm-r-bert-base-nli-stsb-mean-tokens")
+            return SentenceTransformerBackend("paraphrase-multilingual-mpnet-base-v2")
         else:
             raise ValueError(f"{language} is currently not supported. However, you can "
                              f"create any embeddings yourself and pass it through fit_transform(docs, embeddings)\n"
                              "Else, please select a language from the following list:\n"
                              f"{languages}")
 
-    return SentenceTransformerBackend("xlm-r-bert-base-nli-stsb-mean-tokens")
+    return SentenceTransformerBackend("paraphrase-multilingual-mpnet-base-v2")

--- a/bertopic/backend/_utils.py
+++ b/bertopic/backend/_utils.py
@@ -21,8 +21,8 @@ languages = ['afrikaans', 'albanian', 'amharic', 'arabic', 'armenian', 'assamese
 def select_backend(embedding_model,
                    language: str = None) -> BaseEmbedder:
     """ Select an embedding model based on language or a specific sentence transformer models.
-    When selecting a language, we choose paraphrase-mpnet-base-v2 for English and
-    paraphrase-multilingual-mpnet-base-v2 for all other languages as it support 100+ languages.
+    When selecting a language, we choose paraphrase-MiniLM-L6-v2 for English and
+    paraphrase-multilingual-MiniLM-L12-v2 for all other languages as it support 100+ languages.
 
     Returns:
         model: Either a Sentence-Transformer or Flair model
@@ -62,13 +62,13 @@ def select_backend(embedding_model,
     # Select embedding model based on language
     if language:
         if language.lower() in ["English", "english", "en"]:
-            return SentenceTransformerBackend("paraphrase-mpnet-base-v2")
+            return SentenceTransformerBackend("paraphrase-MiniLM-L6-v2")
         elif language.lower() in languages or language == "multilingual":
-            return SentenceTransformerBackend("paraphrase-multilingual-mpnet-base-v2")
+            return SentenceTransformerBackend("paraphrase-multilingual-MiniLM-L12-v2")
         else:
             raise ValueError(f"{language} is currently not supported. However, you can "
                              f"create any embeddings yourself and pass it through fit_transform(docs, embeddings)\n"
                              "Else, please select a language from the following list:\n"
                              f"{languages}")
 
-    return SentenceTransformerBackend("paraphrase-multilingual-mpnet-base-v2")
+    return SentenceTransformerBackend("paraphrase-MiniLM-L6-v2")

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,8 +7,8 @@ with different parameters.
 ## **Which embedding model works best for which language?**
 Unfortunately, there is not a definitive list of the best models for each language, this highly depends 
 on your data, the model, and your specific use-case. However, the default model in BERTopic 
-(`"paraphrase-mpnet-base-v2"`) works great for **English** documents. In contrast, for **multi-lingual** 
-documents or any other language, `"paraphrase-multilingual-mpnet-base-v2""` has shown great performance.  
+(`"paraphrase-MiniLM-L6-v2"`) works great for **English** documents. In contrast, for **multi-lingual** 
+documents or any other language, `"paraphrase-multilingual-MiniLM-L12-v2""` has shown great performance.  
 
 If you want to use a model that is a bit faster, then I would advise using `paraphrase-MiniLM-L6-v2` instead. 
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,12 +7,10 @@ with different parameters.
 ## **Which embedding model works best for which language?**
 Unfortunately, there is not a definitive list of the best models for each language, this highly depends 
 on your data, the model, and your specific use-case. However, the default model in BERTopic 
-(`"distilbert-base-nli-stsb-mean-tokens"`) works great for **English** documents. In contrast, for **multi-lingual** 
-documents or any other language, `"xlm-r-bert-base-nli-stsb-mean-tokens""` has shown great performance.  
+(`"paraphrase-mpnet-base-v2"`) works great for **English** documents. In contrast, for **multi-lingual** 
+documents or any other language, `"paraphrase-multilingual-mpnet-base-v2""` has shown great performance.  
 
-Having said that, I have been getting great performance from the new `stsb-mpnet-base-v2` model in sentence-transformers 
-and I would advise trying it out for **English** documents. If you want to use a model that is a 
-bit faster, then I would advise using `paraphrase-MiniLM-L6-v2` instead. 
+If you want to use a model that is a bit faster, then I would advise using `paraphrase-MiniLM-L6-v2` instead. 
 
 **SentenceTransformers**  
 [SentenceTransformers](https://www.sbert.net/docs/pretrained_models.html#sentence-embedding-models) work typically quite well 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,7 +10,7 @@ on your data, the model, and your specific use-case. However, the default model 
 (`"paraphrase-MiniLM-L6-v2"`) works great for **English** documents. In contrast, for **multi-lingual** 
 documents or any other language, `"paraphrase-multilingual-MiniLM-L12-v2""` has shown great performance.  
 
-If you want to use a model that is a bit faster, then I would advise using `paraphrase-MiniLM-L6-v2` instead. 
+If you want to use a model that provides a higher quality, but takes more compute time, then I would advise using `paraphrase-mpnet-base-v2` and `paraphrase-multilingual-mpnet-base-v2` instead. 
 
 **SentenceTransformers**  
 [SentenceTransformers](https://www.sbert.net/docs/pretrained_models.html#sentence-embedding-models) work typically quite well 

--- a/docs/tutorial/algorithm/algorithm.md
+++ b/docs/tutorial/algorithm/algorithm.md
@@ -18,8 +18,8 @@ language and are great for creating either document- or sentence-embeddings.
 
 In BERTopic, you can choose any sentence transformers model but there are two models that are set as defaults:
 
-* `"distilbert-base-nli-stsb-mean-tokens"`
-* `"xlm-r-bert-base-nli-stsb-mean-tokens"`
+* `"paraphrase-mpnet-base-v2"`
+* `"paraphrase-multilingual-mpnet-base-v2"`
 
 The first is an English BERT-based model trained specifically for semantic similarity tasks which work quite 
 well for most use-cases. The second model is very similar to the first with one major difference is that the 

--- a/docs/tutorial/algorithm/algorithm.md
+++ b/docs/tutorial/algorithm/algorithm.md
@@ -18,8 +18,8 @@ language and are great for creating either document- or sentence-embeddings.
 
 In BERTopic, you can choose any sentence transformers model but there are two models that are set as defaults:
 
-* `"paraphrase-mpnet-base-v2"`
-* `"paraphrase-multilingual-mpnet-base-v2"`
+* `"paraphrase-MiniLM-L6-v2"`
+* `"paraphrase-multilingual-MiniLM-L12-v2"`
 
 The first is an English BERT-based model trained specifically for semantic similarity tasks which work quite 
 well for most use-cases. The second model is very similar to the first with one major difference is that the 

--- a/docs/tutorial/embeddings/embeddings.md
+++ b/docs/tutorial/embeddings/embeddings.md
@@ -9,7 +9,7 @@ and pass it through BERTopic with `embedding_model`:
 
 ```python
 from bertopic import BERTopic
-topic_model = BERTopic(embedding_model="xlm-r-bert-base-nli-stsb-mean-tokens")
+topic_model = BERTopic(embedding_model="paraphrase-mpnet-base-v2")
 ```
 
 Or select a SentenceTransformer model with your parameters:
@@ -17,7 +17,7 @@ Or select a SentenceTransformer model with your parameters:
 ```python
 from sentence_transformers import SentenceTransformer
 
-sentence_model = SentenceTransformer("distilbert-base-nli-mean-tokens", device="cuda")
+sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
 topic_model = BERTopic(embedding_model=sentence_model)
 ```
 

--- a/docs/tutorial/embeddings/embeddings.md
+++ b/docs/tutorial/embeddings/embeddings.md
@@ -9,7 +9,7 @@ and pass it through BERTopic with `embedding_model`:
 
 ```python
 from bertopic import BERTopic
-topic_model = BERTopic(embedding_model="paraphrase-mpnet-base-v2")
+topic_model = BERTopic(embedding_model="paraphrase-MiniLM-L6-v2")
 ```
 
 Or select a SentenceTransformer model with your parameters:
@@ -17,7 +17,7 @@ Or select a SentenceTransformer model with your parameters:
 ```python
 from sentence_transformers import SentenceTransformer
 
-sentence_model = SentenceTransformer("paraphrase-mpnet-base-v2")
+sentence_model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
 topic_model = BERTopic(embedding_model=sentence_model)
 ```
 


### PR DESCRIPTION
Hi,
I love the nice repository you have. Great work!

Over the last weeks, I trained substantially better sentence-transformers models which are now available. The two models I can recommend are:
paraphrase-mpnet-base-v2 <= for English
paraphrase-multilingual-mpnet-base-v2   <= for 50+ languages


The  models are substantially better than any previous model. For example, when evaluating for clustering on the 20Newsgroups dataset, the performance (V-Measure) of the paraphrase-mpnet-base-v2 is at 47.8 while the currently used model in BERTTopic (distilbert-base-nli-mean-tokens) is just at 27.9 => We have a +20 points improvement.

The new models have been extensively evaluated on 15 different datasets and task, and they are substantially better on all datasets. The largest gains are for noisy data like user written text (Twitter, Reddit etc.)

If you like faster models, I can recommend:
paraphrase-MiniLM-L6-v2    <= for English
paraphrase-multilingual-MiniLM-L12-v2  <= for 50+ languages


========================


In this pull request, I hope I replaced all references of the old model to the new paraphrase-mpnet-base-v2 model. Also I removed at two places the manual setting of the device. The device is automatically determined, so usually it is better not to set it manually.


Let me know if you  have further questions.
