### PR TITLE
Fix issue with UMAP import

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -13,7 +13,7 @@ from typing import List, Tuple, Union, Mapping, Any
 
 # Models
 import hdbscan
-from umap import UMAP
+import umap.umap_ as UMAP
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.preprocessing import normalize

--- a/bertopic/plotting/_topics.py
+++ b/bertopic/plotting/_topics.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from umap import UMAP
+import umap.umap_ as UMAP
 from typing import List
 from sklearn.preprocessing import MinMaxScaler
 


### PR DESCRIPTION
- Modify UMAP import.

Explanation:
When trying to import `bertopic` I was getting an AttributeError related to UMAP import, saying:
`module umap has no attribute UMAP`
I checked that I had the correct version of `umap-learn` but still it wasn't working. Changing the imports as in the PR solved the issue. 😊