### PR TITLE
Fix embeddings tutorial typo at spaCy section

### DIFF
--- a/docs/tutorial/embeddings/embeddings.md
+++ b/docs/tutorial/embeddings/embeddings.md
@@ -50,9 +50,6 @@ topic_model = BERTopic(embedding_model=document_glove_embeddings)
 ### **Spacy**
 [Spacy](https://github.com/explosion/spaCy) is an amazing framework for processing text. There are 
 many models available across many languages for modeling text. 
- 
- allows you to choose almost any embedding model that 
-is publicly available. Flair can be used as follows:
 
 To use Spacy's non-transformer models in BERTopic:
 


### PR DESCRIPTION
Just a small fix at the embeddings tutorial at the spaCy section. It seems that this piece of the Flair instructions had been left at the spaCy's one:

``` 
allows you to choose almost any embedding model that is publicly available. Flair can be used as follows:
```