### PR TITLE
Added support for barplotting more than 9 topics

### DIFF
--- a/bertopic/plotting/_barchart.py
+++ b/bertopic/plotting/_barchart.py
@@ -7,10 +7,9 @@ from plotly.subplots import make_subplots
 
 def visualize_barchart(topic_model,
                        topics: List[int] = None,
-                       top_n_topics: int = 6,
+                       top_n_topics: int = 8,
                        n_words: int = 5,
-                       width: int = 800,
-                       height: int = 600) -> go.Figure:
+                       columns: int = 4) -> go.Figure:
     """ Visualize a barchart of selected topics
 
     Arguments:
@@ -18,8 +17,7 @@ def visualize_barchart(topic_model,
         topics: A selection of topics to visualize.
         top_n_topics: Only select the top n most frequent topics.
         n_words: Number of words to show in a topic
-        width: The width of the figure.
-        height: The height of the figure.
+        columns: Number of columns to plot.
 
     Returns:
         fig: A plotly figure
@@ -52,13 +50,13 @@ def visualize_barchart(topic_model,
 
     # Initialize figure
     subplot_titles = [f"Topic {topic}" for topic in topics]
-    columns = 3
+    columns = 4
     rows = int(np.ceil(len(topics) / columns))
     fig = make_subplots(rows=rows,
                         cols=columns,
                         shared_xaxes=True,
                         horizontal_spacing=.15,
-                        vertical_spacing=.15,
+                        vertical_spacing=.2/rows,
                         subplot_titles=subplot_titles)
 
     # Add barchart for each topic
@@ -86,24 +84,24 @@ def visualize_barchart(topic_model,
         showlegend=False,
         title={
             'text': "<b>Topic Word Scores",
-            'y': .95,
-            'x': .15,
-            'xanchor': 'center',
-            'yanchor': 'top',
             'font': dict(
                 size=22,
                 color="Black")
         },
-        width=width,
-        height=height,
+        width=220*columns,
+        autosize=False,
+        height=200+25*top_n_topics,
+        uniformtext={"mode": "show", "minsize": 8},
+        margin_t=100,
         hoverlabel=dict(
             bgcolor="white",
             font_size=16,
             font_family="Rockwell"
         ),
     )
-
-    fig.update_xaxes(showgrid=True)
-    fig.update_yaxes(showgrid=True)
+    
+    fig.update_xaxes(showgrid=True,automargin=True,showticklabels=False)
+    fig.update_yaxes(showgrid=True,automargin=True,nticks=n_words)
 
     return fig
+  

--- a/bertopic/plotting/_barchart.py
+++ b/bertopic/plotting/_barchart.py
@@ -9,6 +9,8 @@ def visualize_barchart(topic_model,
                        topics: List[int] = None,
                        top_n_topics: int = 8,
                        n_words: int = 5,
+                       title: str = 'Topic Word Scores',
+                       normalize: bool = True,
                        columns: int = 4) -> go.Figure:
     """ Visualize a barchart of selected topics
 
@@ -18,6 +20,8 @@ def visualize_barchart(topic_model,
         top_n_topics: Only select the top n most frequent topics.
         n_words: Number of words to show in a topic
         columns: Number of columns to plot.
+        normalize: Sets x-axis max value to highest score (True, default) or 1 (False).
+        title: Sets title of plot.
 
     Returns:
         fig: A plotly figure
@@ -62,16 +66,17 @@ def visualize_barchart(topic_model,
     # Add barchart for each topic
     row = 1
     column = 1
+    max_score = []
     for topic in topics:
         words = [word + "  " for word, _ in topic_model.get_topic(topic)][:n_words][::-1]
         scores = [score for _, score in topic_model.get_topic(topic)][:n_words][::-1]
-
+        if normalize==True:
+          max_score.append(max(scores))
         fig.add_trace(
             go.Bar(x=scores,
                    y=words,
                    orientation='h'),
             row=row, col=column)
-
         if column == columns:
             column = 1
             row += 1
@@ -83,7 +88,7 @@ def visualize_barchart(topic_model,
         template="plotly_white",
         showlegend=False,
         title={
-            'text': "<b>Topic Word Scores",
+            'text': f"<b>{title}",
             'font': dict(
                 size=22,
                 color="Black")
@@ -99,9 +104,15 @@ def visualize_barchart(topic_model,
             font_family="Rockwell"
         ),
     )
-    
-    fig.update_xaxes(showgrid=True,automargin=True,showticklabels=False)
+
+    fig.update_xaxes(showgrid=True,automargin=True,showticklabels=False,fixedrange=True)
     fig.update_yaxes(showgrid=True,automargin=True,nticks=n_words)
 
+    ticksize = 5
+    if normalize==True:
+        fig.update_xaxes(range=[0,max(max_score)], dtick=max(max_score)/ticksize)
+    else:
+        fig.update_xaxes(range=[0,1], dtick=1/ticksize)
+
     return fig
-  
+


### PR DESCRIPTION
Before this patch, the subplots became smaller and smaller the more topics you added. Was unusable above 18 topics and **_broke entirely_** when slightly larger than that, and with cryptic errors too. Width and height controls were exposed but required very careful and frustrating study of how each added and removed row would change the size of each subplot.

Now the subplots are more or less the same size all the time. Instead of height and width settings it now takes number of desired columns instead and scales size according to number of columns and number of topics. Changed default columns from 3 to 4 because it's a bit less wasteful. 3 columns still looks nice though. I tested it thoroughly within the confines of the data I'm working with and it looks good to go.

The reason for the strange-looking `height=200+25*top_n_topics` is that when top_n_topics are sufficiently small, the plots became very small without a minimum size. 200 is a good minimum height in case of very few topics. I can't really explain why the horizontal and vertical spacing works the way it does now, but it really does work well. It has something to do with how plotly automatically scales everything in a confusing way.

I changed the positioning of the title slightly because it decided to place itself inside the plots when plotting about 200 topics.

I removed the x-axis labeling because it was misleading because it's per column. That means a 20px long bar in column 1 means something entirely different than a 20px long bar in column 2 and so on. It also isn't really that meaningful to look at actual probabilities like that anyway, what matters is the proportion between the bars in my opinion. Maybe it would be cool to normalize the length of the bars per subplot, so the total adds up to 1? I think that would make sense.

I spent quite a while tweaking the scaling, but a perfectionist might be able to make it slightly better by actually measuring pixels per row instead of estimating it empirically like I did. At least it's usable and working as intended now, and looking good too.

It would be nice to scale horizontal spacing and width by the longest label, because currently it's possible to overlap with extremely long labels, and shortening them doesn't really make a lot of sense to me.