### PR TITLE
Barplot x-axes are now the same length by default

### DIFF
--- a/bertopic/plotting/_barchart.py
+++ b/bertopic/plotting/_barchart.py
@@ -7,10 +7,9 @@ from plotly.subplots import make_subplots
 
 def visualize_barchart(topic_model,
                        topics: List[int] = None,
-                       top_n_topics: int = 6,
+                       top_n_topics: int = 8,
                        n_words: int = 5,
-                       width: int = 800,
-                       height: int = 600) -> go.Figure:
+                       columns: int = 4) -> go.Figure:
     """ Visualize a barchart of selected topics
 
     Arguments:
@@ -18,8 +17,7 @@ def visualize_barchart(topic_model,
         topics: A selection of topics to visualize.
         top_n_topics: Only select the top n most frequent topics.
         n_words: Number of words to show in a topic
-        width: The width of the figure.
-        height: The height of the figure.
+        columns: Number of columns to plot.
 
     Returns:
         fig: A plotly figure
@@ -52,13 +50,13 @@ def visualize_barchart(topic_model,
 
     # Initialize figure
     subplot_titles = [f"Topic {topic}" for topic in topics]
-    columns = 3
+    columns = 4
     rows = int(np.ceil(len(topics) / columns))
     fig = make_subplots(rows=rows,
                         cols=columns,
                         shared_xaxes=True,
                         horizontal_spacing=.15,
-                        vertical_spacing=.15,
+                        vertical_spacing=.2/rows,
                         subplot_titles=subplot_titles)
 
     # Add barchart for each topic
@@ -86,24 +84,24 @@ def visualize_barchart(topic_model,
         showlegend=False,
         title={
             'text': "<b>Topic Word Scores",
-            'y': .95,
-            'x': .15,
-            'xanchor': 'center',
-            'yanchor': 'top',
             'font': dict(
                 size=22,
                 color="Black")
         },
-        width=width,
-        height=height,
+        width=220*columns,
+        autosize=False,
+        height=200+25*top_n_topics,
+        uniformtext={"mode": "show", "minsize": 8},
+        margin_t=100,
         hoverlabel=dict(
             bgcolor="white",
             font_size=16,
             font_family="Rockwell"
         ),
     )
-
-    fig.update_xaxes(showgrid=True)
-    fig.update_yaxes(showgrid=True)
+    
+    fig.update_xaxes(showgrid=True,automargin=True,showticklabels=False)
+    fig.update_yaxes(showgrid=True,automargin=True,nticks=n_words)
 
     return fig
+  

--- a/bertopic/plotting/_barchart.py
+++ b/bertopic/plotting/_barchart.py
@@ -9,6 +9,8 @@ def visualize_barchart(topic_model,
                        topics: List[int] = None,
                        top_n_topics: int = 8,
                        n_words: int = 5,
+                       title: str = 'Topic Word Scores',
+                       normalize: bool = True,
                        columns: int = 4) -> go.Figure:
     """ Visualize a barchart of selected topics
 
@@ -18,6 +20,8 @@ def visualize_barchart(topic_model,
         top_n_topics: Only select the top n most frequent topics.
         n_words: Number of words to show in a topic
         columns: Number of columns to plot.
+        normalize: Sets x-axis max value to highest score (True, default) or 1 (False).
+        title: Sets title of plot.
 
     Returns:
         fig: A plotly figure
@@ -62,16 +66,17 @@ def visualize_barchart(topic_model,
     # Add barchart for each topic
     row = 1
     column = 1
+    max_score = []
     for topic in topics:
         words = [word + "  " for word, _ in topic_model.get_topic(topic)][:n_words][::-1]
         scores = [score for _, score in topic_model.get_topic(topic)][:n_words][::-1]
-
+        if normalize==True:
+          max_score.append(max(scores))
         fig.add_trace(
             go.Bar(x=scores,
                    y=words,
                    orientation='h'),
             row=row, col=column)
-
         if column == columns:
             column = 1
             row += 1
@@ -83,7 +88,7 @@ def visualize_barchart(topic_model,
         template="plotly_white",
         showlegend=False,
         title={
-            'text': "<b>Topic Word Scores",
+            'text': f"<b>{title}",
             'font': dict(
                 size=22,
                 color="Black")
@@ -99,9 +104,15 @@ def visualize_barchart(topic_model,
             font_family="Rockwell"
         ),
     )
-    
-    fig.update_xaxes(showgrid=True,automargin=True,showticklabels=False)
+
+    fig.update_xaxes(showgrid=True,automargin=True,showticklabels=False,fixedrange=True)
     fig.update_yaxes(showgrid=True,automargin=True,nticks=n_words)
 
+    ticksize = 5
+    if normalize==True:
+        fig.update_xaxes(range=[0,max(max_score)], dtick=max(max_score)/ticksize)
+    else:
+        fig.update_xaxes(range=[0,1], dtick=1/ticksize)
+
     return fig
-  
+


### PR DESCRIPTION
Before, x-axes were shared per column which was misleading. Now all x-axes are the same by default, or a range from 0-1 (sort of useful for finding extremely overfit topics).


Also added the option to change the title.