### PR TITLE
tqdm import: autodetect if in a notebook environment

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -13,7 +13,7 @@ import joblib
 import inspect
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
+from tqdm.autonotebook import tqdm
 from scipy.sparse.csr import csr_matrix
 from typing import List, Tuple, Union, Mapping, Any
 


### PR DESCRIPTION
Would be nice, works better in a jupyter notebook.
It chooses regular tqdm if not in a notebook.
[I would like it because it sometimes looks like this in my google colab notebook.](https://imgur.com/a/bSfpy4M)