### PR TITLE
Tqdm autodetects if in a notebook environment or not

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -13,7 +13,7 @@ import joblib
 import inspect
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
+from tqdm.autonotebook import tqdm
 from scipy.sparse.csr import csr_matrix
 from typing import List, Tuple, Union, Mapping, Any
 


### PR DESCRIPTION
It looks nicer this way and it chooses regular tqdm if it's not in a notebook.
[It's because my google colab notebook sometimes looks like this without it.](https://imgur.com/a/bSfpy4M)