### PR TITLE
Dendrogram color threshold

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -1102,6 +1102,7 @@ class BERTopic:
                             orientation: str = "left",
                             topics: List[int] = None,
                             top_n_topics: int = None,
+                            color_threshold: float = 1,
                             width: int = 1000,
                             height: int = 600) -> go.Figure:
         """ Visualize a hierarchical structure of the topics
@@ -1115,6 +1116,7 @@ class BERTopic:
                          Either 'left' or 'bottom'
             topics: A selection of topics to visualize
             top_n_topics: Only select the top n most frequent topics
+            color_threshold: Adjust dendrogram link coloring threshold.
             width: The width of the figure. Only works if orientation is set to 'left'
             height: The height of the figure. Only works if orientation is set to 'bottom'
 
@@ -1142,6 +1144,7 @@ class BERTopic:
                                             orientation=orientation,
                                             topics=topics,
                                             top_n_topics=top_n_topics,
+                                            color_threshold=color_threshold,
                                             width=width,
                                             height=height)
 

--- a/bertopic/plotting/_hierarchy.py
+++ b/bertopic/plotting/_hierarchy.py
@@ -87,7 +87,6 @@ def visualize_hierarchy(topic_model,
 
     # Stylize layout
     fig.update_layout(
-        plot_bgcolor='#ECEFF1',
         template="plotly_white",
         title={
             'text': "<b>Hierarchical Clustering",
@@ -104,22 +103,29 @@ def visualize_hierarchy(topic_model,
             font_family="Rockwell"
         ),
     )
-
+    fig.update_xaxes(ticks="")
+    fig.update_yaxes(ticks="")
+    ticksize = 0
     # Stylize orientation
     if orientation == "left":
         fig.update_layout(height=200+(15*len(topics)),
                           width=width,
                           yaxis=dict(tickmode="array",
                                      ticktext=new_labels))
+        fig.update_xaxes(ticks="")
+        fig.update_yaxes(ticks="")
         
         # Fix empty space on the bottom of the graph
         y_max = max([trace['y'].max()+5 for trace in fig['data']])
         y_min = min([trace['y'].min()-5 for trace in fig['data']])
-        fig.update_layout(yaxis=dict(range=[y_min, y_max]))
+        fig.update_layout(yaxis=dict(range=[y_min, y_max]),
+                          xaxis=dict(visible= False, showticklabels = False))
 
     else:
         fig.update_layout(width=200+(15*len(topics)),
                           height=height,
                           xaxis=dict(tickmode="array",
-                                     ticktext=new_labels))
+                                     ticktext=new_labels),
+                          yaxis=dict(visible= False,
+                                     showticklabels = False))
     return fig

--- a/bertopic/plotting/_hierarchy.py
+++ b/bertopic/plotting/_hierarchy.py
@@ -11,6 +11,7 @@ def visualize_hierarchy(topic_model,
                         orientation: str = "left",
                         topics: List[int] = None,
                         top_n_topics: int = None,
+                        color_threshold: float = 1,
                         width: int = 1000,
                         height: int = 600) -> go.Figure:
     """ Visualize a hierarchical structure of the topics
@@ -25,6 +26,7 @@ def visualize_hierarchy(topic_model,
                      Either 'left' or 'bottom'
         topics: A selection of topics to visualize
         top_n_topics: Only select the top n most frequent topics
+        color_threshold: Adjust dendrogram link coloring threshold.
         width: The width of the figure. Only works if orientation is set to 'left'
         height: The height of the figure. Only works if orientation is set to 'bottom'
 
@@ -74,7 +76,7 @@ def visualize_hierarchy(topic_model,
     fig = ff.create_dendrogram(distance_matrix,
                                orientation=orientation,
                                linkagefun=lambda x: linkage(x, "ward"),
-                               color_threshold=1)
+                               color_threshold=color_threshold)
 
     # Create nicer labels
     axis = "yaxis" if orientation == "left" else "xaxis"


### PR DESCRIPTION
If this parameter isn't exposed, the dendrogram will often generate plots with inexplicable colors. I personally prefer setting it to 2, but 1 was set before so I'm assuming it's a good default setting.