### PR TITLE
don't save the fitted vectorizer model in the model!

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -21,6 +21,7 @@ from typing import List, Tuple, Union, Mapping, Any
 import hdbscan
 from umap import UMAP
 from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.base import clone
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.preprocessing import normalize
 
@@ -1575,7 +1576,7 @@ class BERTopic:
         """
         documents = self._preprocess_text(documents_per_topic.Document.values)
 
-        fitted_vectorizer = self.vectorizer_model.fit(documents)
+        fitted_vectorizer = clone(self.vectorizer_model).fit(documents)
 
         words = fitted_vectorizer.get_feature_names_out()
         X = fitted_vectorizer.transform(documents)

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -1587,8 +1587,7 @@ class BERTopic:
         else:
             multiplier = None
 
-        if fit:
-            self.transformer = ClassTFIDF().fit(X, multiplier=multiplier)
+        self.transformer = ClassTFIDF().fit(X, multiplier=multiplier)
 
         c_tf_idf = self.transformer.transform(X)
 

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -1566,7 +1566,8 @@ class BERTopic:
 
             self.topic_embeddings = topic_embeddings
 
-    def _c_tf_idf(self, documents_per_topic: pd.DataFrame, **models) -> Tuple[csr_matrix, List[str]]:
+    def _c_tf_idf(self, documents_per_topic: pd.DataFrame, 
+                  **fitted_models: "vectorizer_=CountVectorizer.fit() c_tf_idf_=ClassTFIDF().fit()") -> Tuple[csr_matrix, List[str]]:
         """ Calculate a class-based TF-IDF where m is the number of total documents.
 
         Arguments:
@@ -1584,8 +1585,8 @@ class BERTopic:
         """
         documents = self._preprocess_text(documents_per_topic.Document.values)
 
-        if "vectorizer_" in models:
-            vectorizer_ = models["vectorizer_"]
+        if "vectorizer_" in fitted_models:
+            vectorizer_ = fitted_models["vectorizer_"]
         else:
             vectorizer_ = clone(self.vectorizer_model)
             vectorizer_.fit(documents)
@@ -1599,15 +1600,15 @@ class BERTopic:
         else:
             multiplier = None
 
-        if "c_tf_idf_" in models and models['c_tf_idf_'] != 0:
-            c_tf_idf_ = models["c_tf_idf_"]
+        if "c_tf_idf_" in fitted_models and fitted_models['c_tf_idf_'] != 0:
+            c_tf_idf_ = fitted_models["c_tf_idf_"]
         else:
             c_tf_idf_ = ClassTFIDF().fit(X, multiplier=multiplier)
 
         c_tf_idf = c_tf_idf_.transform(X)
 
         self.topic_sim_matrix = cosine_similarity(c_tf_idf)
-        if models not {}:
+        if fitted_models not {}:
             return c_tf_idf, words, c_tf_idf_
         else:
             return c_tf_idf, words

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -582,7 +582,7 @@ class BERTopic:
             selection = documents.loc[documents.Class == class_, :]
             documents_per_topic = selection.groupby(['Topic'], as_index=False).agg({'Document': ' '.join,
                                                                                     "Class": "count"})
-            c_tf_idf, words, c_tf_idf_model = self._c_tf_idf(documents_per_topic, vectorizer_ = vectorizer_, c_tf_idf_ = c_tf_idf_model)
+            c_tf_idf, words, c_tf_idf_model = self._c_tf_idf(documents_per_topic, vectorizer_ = vectorizer_model, c_tf_idf_ = c_tf_idf_model)
 
             # Fine-tune the timestamp c-TF-IDF representation based on the global c-TF-IDF representation
             # by simply taking the average of the two

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -17,6 +17,9 @@ from tqdm import tqdm
 from scipy.sparse.csr import csr_matrix
 from typing import List, Tuple, Union, Mapping, Any
 
+# For compressing BERTopic attributes
+import zlib, pickle
+
 # Models
 import hdbscan
 from umap import UMAP
@@ -71,6 +74,17 @@ class BERTopic:
     try out BERTopic several times until you find the topics that suit
     you best.
     """
+    # When objects are stored in BERTopic, compress them. Decompress on retrieval.
+    def __getattr__(self, value):
+        value = object.__getattr__(value)
+        value = zlib.decompress(value)
+        value = pickle.loads(value)
+        return value
+    def __setattr__(self, key, value):
+        value = pickle.dumps(value)
+        value = zlib.compress(value)
+        object.__setattr__(key, value)
+            
     def __init__(self,
                  language: str = "english",
                  top_n_words: int = 10,

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -455,7 +455,7 @@ class BERTopic:
         check_documents_type(docs)
         documents = pd.DataFrame({"Document": docs, "Topic": topics, "Timestamps": timestamps})
         global_c_tf_idf = normalize(self.c_tf_idf, axis=1, norm='l1', copy=False)
-        vectorizer_model = clone(self.vectorizer_model).fit(documents)
+        vectorizer_model = clone(self.vectorizer_model).fit(docs)
         c_tf_idf_model = 0 # gets fitted later
 
         all_topics = sorted(list(documents.Topic.unique()))
@@ -571,7 +571,7 @@ class BERTopic:
         """
         documents = pd.DataFrame({"Document": docs, "Topic": topics, "Class": classes})
         global_c_tf_idf = normalize(self.c_tf_idf, axis=1, norm='l1', copy=False)
-        vectorizer_model = clone(self.vectorizer_model).fit(documents)
+        vectorizer_model = clone(self.vectorizer_model).fit(docs)
         c_tf_idf_model = 0 # gets fitted later
         
         # For each unique timestamp, create topic representations

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -1590,7 +1590,7 @@ class BERTopic:
             vectorizer_ = clone(self.vectorizer_model)
             vectorizer_.fit(documents)
 
-        words = vectorizer_.get_feature_names()
+        words = vectorizer_.get_feature_names_out()
         X = vectorizer_.transform(documents)
 
         if self.seed_topic_list:

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -1589,7 +1589,6 @@ class BERTopic:
 
         self.transformer = ClassTFIDF().fit(X, multiplier=multiplier)
 
-        c_tf_idf = self.transformer.transform(X)
 
         self.topic_sim_matrix = cosine_similarity(c_tf_idf)
 


### PR DESCRIPTION
A fix to https://github.com/MaartenGr/BERTopic/issues/383

Storing a fitted `vectorizer_model` makes the topic model extremely memory hungry. This way, `self._c_tf_idf` is slower, but it's anyway only ever sped up in the second run in the case of doing `topics_over_time` or `topics_per_class` *after* already fitting the model once.

CountVectorizer is pretty fast already (takes about 2 minutes on my 48.000 document dataset), so I don't think it's worth storing the entire fitted model just to `.get_feature_names()` a little faster in special use cases compared to the cost in memory. It's in most use cases only fitted once, and the fitting stage isn't time-sensitive either. Plus, the `.transform(documents)` that had to be done anyway still fits first anyway, so the speedup isn't so big in the first place.

Also updated `.get_feature_names()` to `.get_feature_names_out()`, as the former is deprecated and will stop working with sklearn 1.2, which will be out soon.