### PR TITLE
fix RuntimeError when used as sklearn estimator

### DIFF
--- a/bertopic/_ctfidf.py
+++ b/bertopic/_ctfidf.py
@@ -18,8 +18,8 @@ class ClassTFIDF(TfidfTransformer):
     Next, the total, unjoined, number of documents across all classes **m** is divided by the total
     sum of word **i** across all classes.
     """
-    def __init__(self, *args, **kwargs):
-        super(ClassTFIDF, self).__init__(*args, **kwargs)
+    def __init__(self):
+        super(ClassTFIDF, self).__init__()
 
     def fit(self, X: sp.csr_matrix, multiplier: np.ndarray = None):
         """Learn the idf vector (global term weights).


### PR DESCRIPTION
Simple fix for a simple bug:
```RuntimeError: scikit-learn estimators should always specify their parameters in the signature of their __init__ (no varargs). <class 'bertopic._ctfidf.ClassTFIDF'> with constructor (self, *args, **kwargs) doesn't  follow this convention.```

It doesn't take any arguments in `__init__`, so there's no need for taking varargs. There are also no arguments used in the _bertopic.py code.