### PR TITLE
Add sorting to Topic order

### DIFF
--- a/bertopic/plotting/_topics_over_time.py
+++ b/bertopic/plotting/_topics_over_time.py
@@ -58,7 +58,7 @@ def visualize_topics_over_time(topic_model,
     topic_names = {key: value[:40] + "..." if len(value) > 40 else value
                    for key, value in topic_model.topic_names.items()}
     topics_over_time["Name"] = topics_over_time.Topic.map(topic_names)
-    data = topics_over_time.loc[topics_over_time.Topic.isin(selected_topics), :].sort_values(["Topic","Timestamp"])
+    data = topics_over_time.loc[topics_over_time.Topic.isin(selected_topics), :].sort_values(["Topic", "Timestamp"])
     
     # Add traces
     fig = go.Figure()

--- a/bertopic/plotting/_topics_over_time.py
+++ b/bertopic/plotting/_topics_over_time.py
@@ -58,8 +58,8 @@ def visualize_topics_over_time(topic_model,
     topic_names = {key: value[:40] + "..." if len(value) > 40 else value
                    for key, value in topic_model.topic_names.items()}
     topics_over_time["Name"] = topics_over_time.Topic.map(topic_names)
-    data = topics_over_time.loc[topics_over_time.Topic.isin(selected_topics), :]
-
+    data = topics_over_time.loc[topics_over_time.Topic.isin(selected_topics), :].sort_values(["Topic","Timestamp"])
+    
     # Add traces
     fig = go.Figure()
     for index, topic in enumerate(data.Topic.unique()):


### PR DESCRIPTION
Adding sorting in the visualize_topics_over_time function before plotting the topics will ensure the legend looks clean and orderly by having the most popular topics at the top. This will also save the user time from having to look through the legend by ordering in a more intuitive way rather than having the user scroll through the legend when looking to select or deselect a topic.

Screenshots for example provided:

Previous:
<img width="1046" alt="previous_visualize_topics_over_time" src="https://user-images.githubusercontent.com/15350110/173988350-7a673b03-b3ca-408e-874c-8ee88636afbc.png">

Now:
<img width="1047" alt="sorted_visalize_topics_over_time" src="https://user-images.githubusercontent.com/15350110/173988390-a02adda5-b7e3-4f88-88d3-388d1e4748bf.png">

