### PR TITLE
Support custom options for all backend models.

### DIFF
--- a/bertopic/backend/_base.py
+++ b/bertopic/backend/_base.py
@@ -21,7 +21,8 @@ class BaseEmbedder:
 
     def embed(self,
               documents: List[str],
-              verbose: bool = False) -> np.ndarray:
+              verbose: bool = False,
+              **kwargs) -> np.ndarray:
         """ Embed a list of n documents/words into an n-dimensional
         matrix of embeddings
 
@@ -37,7 +38,8 @@ class BaseEmbedder:
 
     def embed_words(self,
                     words: List[str],
-                    verbose: bool = False) -> np.ndarray:
+                    verbose: bool = False,
+                    **kwargs) -> np.ndarray:
         """ Embed a list of n words into an n-dimensional
         matrix of embeddings
 
@@ -50,11 +52,12 @@ class BaseEmbedder:
             that each have an embeddings size of `m`
 
         """
-        return self.embed(words, verbose)
+        return self.embed(words, verbose, **kwargs)
 
     def embed_documents(self,
                         document: List[str],
-                        verbose: bool = False) -> np.ndarray:
+                        verbose: bool = False,
+                        **kwargs) -> np.ndarray:
         """ Embed a list of n words into an n-dimensional
         matrix of embeddings
 
@@ -66,4 +69,4 @@ class BaseEmbedder:
             Document embeddings with shape (n, m) with `n` documents
             that each have an embeddings size of `m`
         """
-        return self.embed(document, verbose)
+        return self.embed(document, verbose, **kwargs)

--- a/bertopic/backend/_flair.py
+++ b/bertopic/backend/_flair.py
@@ -52,7 +52,8 @@ class FlairBackend(BaseEmbedder):
 
     def embed(self,
               documents: List[str],
-              verbose: bool = False) -> np.ndarray:
+              verbose: bool = False,
+              **kwargs) -> np.ndarray:
         """ Embed a list of n documents/words into an n-dimensional
         matrix of embeddings
 
@@ -71,7 +72,7 @@ class FlairBackend(BaseEmbedder):
                 self.embedding_model.embed(sentence)
             except RuntimeError:
                 sentence = Sentence("an empty document")
-                self.embedding_model.embed(sentence)
+                self.embedding_model.embed(sentence, **kwargs)
             embedding = sentence.embedding.detach().cpu().numpy()
             embeddings.append(embedding)
         embeddings = np.asarray(embeddings)

--- a/bertopic/backend/_gensim.py
+++ b/bertopic/backend/_gensim.py
@@ -36,7 +36,8 @@ class GensimBackend(BaseEmbedder):
 
     def embed(self,
               documents: List[str],
-              verbose: bool = False) -> np.ndarray:
+              verbose: bool = False,
+              **kwargs) -> np.ndarray:
         """ Embed a list of n documents/words into an n-dimensional
         matrix of embeddings
 
@@ -58,7 +59,7 @@ class GensimBackend(BaseEmbedder):
             # Extract word embeddings
             for word in doc.split(" "):
                 try:
-                    word_embedding = self.embedding_model.get_vector(word)
+                    word_embedding = self.embedding_model.get_vector(word, **kwargs)
                     doc_embedding.append(word_embedding)
                 except KeyError:
                     doc_embedding.append(empty_vector)

--- a/bertopic/backend/_hftransformers.py
+++ b/bertopic/backend/_hftransformers.py
@@ -42,7 +42,7 @@ class HFTransformerBackend(BaseEmbedder):
 
     def embed(self,
               documents: List[str],
-              verbose: bool = False) -> np.ndarray:
+              verbose: bool = False, **kwargs) -> np.ndarray:
         """ Embed a list of n documents/words into an n-dimensional
         matrix of embeddings
 
@@ -57,7 +57,7 @@ class HFTransformerBackend(BaseEmbedder):
         dataset = MyDataset(documents)
 
         embeddings = []
-        for document, features in tqdm(zip(documents, self.embedding_model(dataset, truncation=True, padding=True)),
+        for document, features in tqdm(zip(documents, self.embedding_model(dataset, truncation=True, padding=True, **kwargs)),
                                        total=len(dataset), disable=not verbose):
             embeddings.append(self._embed(document, features))
 

--- a/bertopic/backend/_sentencetransformers.py
+++ b/bertopic/backend/_sentencetransformers.py
@@ -48,7 +48,8 @@ class SentenceTransformerBackend(BaseEmbedder):
 
     def embed(self,
               documents: List[str],
-              verbose: bool = False) -> np.ndarray:
+              verbose: bool = False,
+              **kwargs) -> np.ndarray:
         """ Embed a list of n documents/words into an n-dimensional
         matrix of embeddings
 
@@ -60,5 +61,5 @@ class SentenceTransformerBackend(BaseEmbedder):
             Document/words embeddings with shape (n, m) with `n` documents/words
             that each have an embeddings size of `m`
         """
-        embeddings = self.embedding_model.encode(documents, show_progress_bar=verbose)
+        embeddings = self.embedding_model.encode(documents, show_progress_bar=verbose, **kwargs)
         return embeddings

--- a/bertopic/backend/_spacy.py
+++ b/bertopic/backend/_spacy.py
@@ -61,7 +61,8 @@ class SpacyBackend(BaseEmbedder):
 
     def embed(self,
               documents: List[str],
-              verbose: bool = False) -> np.ndarray:
+              verbose: bool = False,
+              **kwargs) -> np.ndarray:
         """ Embed a list of n documents/words into an n-dimensional
         matrix of embeddings
 
@@ -79,7 +80,7 @@ class SpacyBackend(BaseEmbedder):
             embeddings = []
             for doc in tqdm(documents, position=0, leave=True, disable=not verbose):
                 try:
-                    embedding = self.embedding_model(doc)._.trf_data.tensors[-1][0].tolist()
+                    embedding = self.embedding_model(doc, **kwargs)._.trf_data.tensors[-1][0].tolist()
                 except:
                     embedding = self.embedding_model("An empty document")._.trf_data.tensors[-1][0].tolist()
                 embeddings.append(embedding)
@@ -90,7 +91,7 @@ class SpacyBackend(BaseEmbedder):
             embeddings = []
             for doc in tqdm(documents, position=0, leave=True, disable=not verbose):
                 try:
-                    vector = self.embedding_model(doc).vector
+                    vector = self.embedding_model(doc, **kwargs).vector
                 except ValueError:
                     vector = self.embedding_model("An empty document").vector
                 embeddings.append(vector)

--- a/bertopic/backend/_use.py
+++ b/bertopic/backend/_use.py
@@ -37,7 +37,8 @@ class USEBackend(BaseEmbedder):
 
     def embed(self,
               documents: List[str],
-              verbose: bool = False) -> np.ndarray:
+              verbose: bool = False,
+              **kwargs) -> np.ndarray:
         """ Embed a list of n documents/words into an n-dimensional
         matrix of embeddings
 
@@ -49,6 +50,6 @@ class USEBackend(BaseEmbedder):
             Document/words embeddings with shape (n, m) with `n` documents/words
             that each have an embeddings size of `m`
         """
-        embeddings = np.array([self.embedding_model([doc]).cpu().numpy()[0]
+        embeddings = np.array([self.embedding_model([doc], **kwargs).cpu().numpy()[0]
                                for doc in tqdm(documents, disable=not verbose)])
         return embeddings

--- a/bertopic/backend/_word_doc.py
+++ b/bertopic/backend/_word_doc.py
@@ -17,7 +17,8 @@ class WordDocEmbedder(BaseEmbedder):
 
     def embed_words(self,
                     words: List[str],
-                    verbose: bool = False) -> np.ndarray:
+                    verbose: bool = False,
+                    **kwargs) -> np.ndarray:
         """ Embed a list of n words into an n-dimensional
         matrix of embeddings
 
@@ -30,11 +31,12 @@ class WordDocEmbedder(BaseEmbedder):
             that each have an embeddings size of `m`
 
         """
-        return self.word_embedding_model.embed(words, verbose)
+        return self.word_embedding_model.embed(words, verbose, **kwargs)
 
     def embed_documents(self,
                         document: List[str],
-                        verbose: bool = False) -> np.ndarray:
+                        verbose: bool = False,
+                        **kwargs) -> np.ndarray:
         """ Embed a list of n words into an n-dimensional
         matrix of embeddings
 
@@ -46,4 +48,4 @@ class WordDocEmbedder(BaseEmbedder):
             Document embeddings with shape (n, m) with `n` documents
             that each have an embeddings size of `m`
         """
-        return self.embedding_model.embed(document, verbose)
+        return self.embedding_model.embed(document, verbose, **kwargs)


### PR DESCRIPTION
### What does this PR do?
Fixes #387 
Support custom options, for example 'batch_size', for all backend models. Here is an example:

> ```
> model = SentenceTransformer(model_name)
> embeddings = model.encode(docs, batch_size=16)
> topic_model = BERTopic(embedding_model=model, calculate_probabilities=True)
> topic_model.fit_transform(docs)
> ```
> After supporting custom options, the above code snippet can be simplified to the following: 
> ```
> topic_model = BERTopic(embedding_model=model_name, calculate_probabilities=True)
> predictions, probs = topic_model.fit_transform(docs, batch_size=16)
> ```

### Who can review?
@MaartenGr 