### PR TITLE
Downgrade joblib due to error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ base_packages = [
     "tqdm>=4.41.1",
     "sentence-transformers>=0.4.1",
     "plotly>=4.7.0",
-    "pyyaml<6.0"
+    "pyyaml<6.0",
+    "joblib==1.1.0"
 ]
 
 flair_packages = [


### PR DESCRIPTION
To reproduce, run this colab: https://colab.research.google.com/drive/1FieRA9fLdkQEGDIMYl0I3MCjSUKVF8C-?usp=sharing
Reference: https://stackoverflow.com/questions/73830225/init-got-an-unexpected-keyword-argument-cachedir-when-importing-top2vec