### PR TITLE
Correcting `iframe` urls in `_bertopic`

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -1619,7 +1619,7 @@ class BERTopic:
         fig.write_html("path/to/file.html")
         ```
 
-        <iframe src="../../getting_started/visualization/documents.html"
+        <iframe src="../getting_started/visualization/documents.html"
         style="width:1000px; height: 800px; border: 0px;""></iframe>
         """
         check_is_fitted(self)
@@ -1723,7 +1723,7 @@ class BERTopic:
         fig.write_html("path/to/file.html")
         ```
 
-        <iframe src="../../getting_started/visualization/hierarchical_documents.html"
+        <iframe src="../getting_started/visualization/hierarchical_documents.html"
         style="width:1000px; height: 770px; border: 0px;""></iframe>
         """
         check_is_fitted(self)
@@ -2013,7 +2013,7 @@ class BERTopic:
         fig = topic_model.visualize_hierarchy()
         fig.write_html("path/to/file.html")
         ```
-        <iframe src="../../getting_started/visualization/hierarchy.html"
+        <iframe src="../getting_started/visualization/hierarchy.html"
         style="width:1000px; height: 680px; border: 0px;""></iframe>
         """
         check_is_fitted(self)


### PR DESCRIPTION
In this [link](https://maartengr.github.io/BERTopic/api/bertopic.html), all the figures can't be found (see the image below)

![image](https://user-images.githubusercontent.com/66799406/197348726-2c7429b0-8812-4051-9467-181c756caca8.png)

I have investigated the problem and fixed it (all is working well on my machine)