### PR TITLE
fix 'cuml' w/ 'hdbscan' type checks in `cluster/_utils.py`

### DIFF
--- a/bertopic/cluster/_utils.py
+++ b/bertopic/cluster/_utils.py
@@ -19,30 +19,36 @@ def hdbscan_delegator(model, func: str, embeddings: np.ndarray = None):
         if isinstance(model, hdbscan.HDBSCAN):
             predictions, probabilities = hdbscan.approximate_predict(model, embeddings)
             return predictions, probabilities
-        elif "cuml" and "hdbscan" in str(type(model)).lower():
+
+        str_type_model = str(type(model)).lower()
+        if "cuml" in str_type_model and "hdbscan" in str_type_model:
             from cuml.cluster import hdbscan as cuml_hdbscan
             predictions, probabilities = cuml_hdbscan.approximate_predict(model, embeddings)
             return predictions, probabilities
-        else:
-            predictions = model.predict(embeddings)
-            return predictions, None
+
+        predictions = model.predict(embeddings)
+        return predictions, None
 
     # All points membership
     if func == "all_points_membership_vectors":
         if isinstance(model, hdbscan.HDBSCAN):
             return hdbscan.all_points_membership_vectors(model)
-        elif "cuml" and "hdbscan" in str(type(model)).lower():
+
+        str_type_model = str(type(model)).lower()
+        if "cuml" in str_type_model and "hdbscan" in str_type_model:
             from cuml.cluster import hdbscan as cuml_hdbscan
             return cuml_hdbscan.all_points_membership_vectors(model)
-        else:
-            return None
+
+        return None
 
 
 def is_supported_hdbscan(model):
     """ Check whether the input model is a supported HDBSCAN-like model """
     if isinstance(model, hdbscan.HDBSCAN):
         return True
-    elif "cuml" and "hdbscan" in str(type(model)).lower():
+
+    str_type_model = str(type(model)).lower()
+    if "cuml" in str_type_model and "hdbscan" in str_type_model:
         return True
-    else:
-        return False
+
+    return False


### PR DESCRIPTION
I believe that current type checks in `bertopic/cluster/_utils.py` for `cuml` + `hdbscan` clusterers are incorrect.

Since the "cuml" string is always evaluating to True (see lines 22, 34, and 45 in `bertopic/cluster/_utils.py`), any subclass of HDBSCAN is triggering the `cuml` import, raising an `ImportError` when not installed. Even if installed, calling `cuml_hdbscan` module may not be adequate for all HDBSCAN subclasses.

I'm opening this PR with a simple solution proposal, but feel free to find another way to fix this issue.