### PR TITLE
Fix typo in textgenerator - [DOCUMENTS] mapping

### DIFF
--- a/bertopic/representation/_textgeneration.py
+++ b/bertopic/representation/_textgeneration.py
@@ -95,7 +95,7 @@ class TextGeneration(BaseRepresentation):
             updated_topics: Updated topic representations
         """
         # Extract the top 4 representative documents per topic
-        if self.prompt != DEFAULT_PROMPT and "[DOCUMENT]" in self.prompt:
+        if self.prompt != DEFAULT_PROMPT and "[DOCUMENTS]" in self.prompt:
             repr_docs_mappings, _, _ = topic_model._extract_representative_docs(c_tf_idf, documents, topics, 500, 4)
         else:
             repr_docs_mappings = {topic: None for topic in topics.keys()}


### PR DESCRIPTION
There is a typo in the current version of the code (line 98):
 - _create_prompt is expecting [DOCUMENTS] while topic_model._extract_representative_docs looks for [DOCUMENT]