### PR TITLE
Improved Prompting

### DIFF
--- a/bertopic/__init__.py
+++ b/bertopic/__init__.py
@@ -1,6 +1,6 @@
 from bertopic._bertopic import BERTopic
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 
 __all__ = [
     "BERTopic",

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3364,9 +3364,9 @@ class BERTopic:
 
         # Map array of probabilities (probability for assigned topic per document)
         if probabilities is not None:
-            if len(probabilities.shape) == 2 and self.get_topic(-1):
+            if len(probabilities.shape) == 2:
                 mapped_probabilities = np.zeros((probabilities.shape[0],
-                                                 len(set(mappings.values())) - 1))
+                                                 len(set(mappings.values())) - self._outliers))
                 for from_topic, to_topic in mappings.items():
                     if to_topic != -1 and from_topic != -1:
                         mapped_probabilities[:, to_topic] += probabilities[:, from_topic]

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -2005,6 +2005,8 @@ class BERTopic:
     def visualize_topics(self,
                          topics: List[int] = None,
                          top_n_topics: int = None,
+                         custom_labels: bool = False,
+                         title: str = "<b>Intertopic Distance Map</b>",
                          width: int = 650,
                          height: int = 650) -> go.Figure:
         """ Visualize topics, their sizes, and their corresponding words
@@ -2015,6 +2017,9 @@ class BERTopic:
         Arguments:
             topics: A selection of topics to visualize
             top_n_topics: Only select the top n most frequent topics
+            custom_labels: Whether to use custom topic labels that were defined using 
+                       `topic_model.set_topic_labels`.
+            title: Title of the plot.
             width: The width of the figure.
             height: The height of the figure.
 
@@ -2037,6 +2042,8 @@ class BERTopic:
         return plotting.visualize_topics(self,
                                          topics=topics,
                                          top_n_topics=top_n_topics,
+                                         custom_labels=custom_labels,
+                                         title=title,
                                          width=width,
                                          height=height)
 
@@ -2049,6 +2056,7 @@ class BERTopic:
                             hide_annotations: bool = False,
                             hide_document_hover: bool = False,
                             custom_labels: bool = False,
+                            title: str = "<b>Documents and Topics</b>",
                             width: int = 1200,
                             height: int = 750) -> go.Figure:
         """ Visualize documents and their topics in 2D
@@ -2071,6 +2079,7 @@ class BERTopic:
                                 specific points. Helps to speed up generation of visualization.
             custom_labels: Whether to use custom topic labels that were defined using
                        `topic_model.set_topic_labels`.
+            title: Title of the plot.
             width: The width of the figure.
             height: The height of the figure.
 
@@ -2129,6 +2138,7 @@ class BERTopic:
                                             hide_annotations=hide_annotations,
                                             hide_document_hover=hide_document_hover,
                                             custom_labels=custom_labels,
+                                            title=title,
                                             width=width,
                                             height=height)
 
@@ -2143,6 +2153,7 @@ class BERTopic:
                                          hide_document_hover: bool = True,
                                          nr_levels: int = 10,
                                          custom_labels: bool = False,
+                                         title: str = "<b>Hierarchical Documents and Topics</b>",
                                          width: int = 1200,
                                          height: int = 750) -> go.Figure:
         """ Visualize documents and their topics in 2D at different levels of hierarchy
@@ -2174,6 +2185,7 @@ class BERTopic:
                            `topic_model.set_topic_labels`.
                            NOTE: Custom labels are only generated for the original
                            un-merged topics.
+            title: Title of the plot.
             width: The width of the figure.
             height: The height of the figure.
 
@@ -2235,6 +2247,7 @@ class BERTopic:
                                                          hide_document_hover=hide_document_hover,
                                                          nr_levels=nr_levels,
                                                          custom_labels=custom_labels,
+                                                         title=title,
                                                          width=width,
                                                          height=height)
 
@@ -2242,6 +2255,7 @@ class BERTopic:
                             topics: List[int] = None,
                             log_scale: bool = False,
                             custom_labels: bool = False,
+                            title: str = "<b>Term score decline per Topic</b>",
                             width: int = 800,
                             height: int = 500) -> go.Figure:
         """ Visualize the ranks of all terms across all topics
@@ -2257,6 +2271,7 @@ class BERTopic:
             log_scale: Whether to represent the ranking on a log scale
             custom_labels: Whether to use custom topic labels that were defined using
                        `topic_model.set_topic_labels`.
+            title: Title of the plot.
             width: The width of the figure.
             height: The height of the figure.
 
@@ -2292,6 +2307,7 @@ class BERTopic:
                                             topics=topics,
                                             log_scale=log_scale,
                                             custom_labels=custom_labels,
+                                            title=title,
                                             width=width,
                                             height=height)
 
@@ -2301,6 +2317,7 @@ class BERTopic:
                                    topics: List[int] = None,
                                    normalize_frequency: bool = False,
                                    custom_labels: bool = False,
+                                   title: str = "<b>Topics over Time</b>",
                                    width: int = 1250,
                                    height: int = 450) -> go.Figure:
         """ Visualize topics over time
@@ -2313,6 +2330,7 @@ class BERTopic:
             normalize_frequency: Whether to normalize each topic's frequency individually
             custom_labels: Whether to use custom topic labels that were defined using
                        `topic_model.set_topic_labels`.
+            title: Title of the plot.
             width: The width of the figure.
             height: The height of the figure.
 
@@ -2342,6 +2360,7 @@ class BERTopic:
                                                    topics=topics,
                                                    normalize_frequency=normalize_frequency,
                                                    custom_labels=custom_labels,
+                                                   title=title,
                                                    width=width,
                                                    height=height)
 
@@ -2351,6 +2370,7 @@ class BERTopic:
                                    topics: List[int] = None,
                                    normalize_frequency: bool = False,
                                    custom_labels: bool = False,
+                                   title: str = "<b>Topics per Class</b>",
                                    width: int = 1250,
                                    height: int = 900) -> go.Figure:
         """ Visualize topics per class
@@ -2363,6 +2383,7 @@ class BERTopic:
             normalize_frequency: Whether to normalize each topic's frequency individually
             custom_labels: Whether to use custom topic labels that were defined using
                        `topic_model.set_topic_labels`.
+            title: Title of the plot.
             width: The width of the figure.
             height: The height of the figure.
 
@@ -2392,6 +2413,7 @@ class BERTopic:
                                                    topics=topics,
                                                    normalize_frequency=normalize_frequency,
                                                    custom_labels=custom_labels,
+                                                   title=title,
                                                    width=width,
                                                    height=height)
 
@@ -2399,6 +2421,7 @@ class BERTopic:
                                probabilities: np.ndarray,
                                min_probability: float = 0.015,
                                custom_labels: bool = False,
+                               title: str = "<b>Topic Probability Distribution</b>",
                                width: int = 800,
                                height: int = 600) -> go.Figure:
         """ Visualize the distribution of topic probabilities
@@ -2409,6 +2432,7 @@ class BERTopic:
                              All others are ignored.
             custom_labels: Whether to use custom topic labels that were defined using
                            `topic_model.set_topic_labels`.
+            title: Title of the plot.
             width: The width of the figure.
             height: The height of the figure.
 
@@ -2433,6 +2457,7 @@ class BERTopic:
                                                probabilities=probabilities,
                                                min_probability=min_probability,
                                                custom_labels=custom_labels,
+                                               title=title,
                                                width=width,
                                                height=height)
 
@@ -2492,6 +2517,7 @@ class BERTopic:
                             topics: List[int] = None,
                             top_n_topics: int = None,
                             custom_labels: bool = False,
+                            title: str = "<b>Hierarchical Clustering</b>",
                             width: int = 1000,
                             height: int = 600,
                             hierarchical_topics: pd.DataFrame = None,
@@ -2514,6 +2540,7 @@ class BERTopic:
                        `topic_model.set_topic_labels`.
                        NOTE: Custom labels are only generated for the original
                        un-merged topics.
+            title: Title of the plot.
             width: The width of the figure. Only works if orientation is set to 'left'
             height: The height of the figure. Only works if orientation is set to 'bottom'
             hierarchical_topics: A dataframe that contains a hierarchy of topics
@@ -2570,6 +2597,7 @@ class BERTopic:
                                             topics=topics,
                                             top_n_topics=top_n_topics,
                                             custom_labels=custom_labels,
+                                            title=title,
                                             width=width,
                                             height=height,
                                             hierarchical_topics=hierarchical_topics,
@@ -2583,6 +2611,7 @@ class BERTopic:
                           top_n_topics: int = None,
                           n_clusters: int = None,
                           custom_labels: bool = False,
+                          title: str = "<b>Similarity Matrix</b>",
                           width: int = 800,
                           height: int = 800) -> go.Figure:
         """ Visualize a heatmap of the topic's similarity matrix
@@ -2597,6 +2626,7 @@ class BERTopic:
                         matrix by those clusters.
             custom_labels: Whether to use custom topic labels that were defined using
                        `topic_model.set_topic_labels`.
+            title: Title of the plot.
             width: The width of the figure.
             height: The height of the figure.
 
@@ -2625,6 +2655,7 @@ class BERTopic:
                                           top_n_topics=top_n_topics,
                                           n_clusters=n_clusters,
                                           custom_labels=custom_labels,
+                                          title=title,
                                           width=width,
                                           height=height)
 

--- a/bertopic/representation/_openai.py
+++ b/bertopic/representation/_openai.py
@@ -28,16 +28,38 @@ Sample texts from this topic:
 Keywords: deliver weeks product shipping long delivery received arrived arrive week
 Topic name: Shipping and delivery issues
 ---
+Topic:
+Sample texts from this topic:
+[DOCUMENTS]
+Keywords: [KEYWORDS]
+Topic name:"""
+
+DEFAULT_CHAT_PROMPT = """
+I have a topic that contains the following documents: 
+[DOCUMENTS]
+The topic is described by the following keywords: [KEYWORDS]
+
+Based on the information above, extract a short topic label in the following format:
+topic: <topic label>
 """
 
 
 class OpenAI(BaseRepresentation):
     """ Using the OpenAI API to generate topic labels based
-    on one of their GPT-3 models. For an overview see:
+    on one of their Completion of ChatCompletion models. 
 
-    https://platform.openai.com/docs/models/gpt-3
+    The default method is `openai.Completion` if `chat=False`. 
+    The prompts will also need to follow a completion task. If you 
+    are looking for a more interactive chats, use `chat=True`
+    with `model=gpt-3.5-turbo`. 
+    
+    For an overview see:
+    https://platform.openai.com/docs/models
 
     Arguments:
+        model: Model to use within OpenAI, defaults to `"text-ada-001"`.
+               NOTE: If a `gpt-3.5-turbo` model is used, make sure to set
+               `chat` to True.
         generator_kwargs: Kwargs passed to `openai.Completion.create`
                           for fine-tuning the output.
         prompt: The prompt to be used in the model. If no prompt is given,
@@ -47,6 +69,8 @@ class OpenAI(BaseRepresentation):
                 inserted.
         delay_in_seconds: The delay in seconds between consecutive prompts 
                           in order to prevent RateLimitErrors. 
+        chat: Set this to True if a GPT-3.5 model is used.
+              See: https://platform.openai.com/docs/models/gpt-3-5
 
     Usage:
 
@@ -62,7 +86,7 @@ class OpenAI(BaseRepresentation):
     from bertopic import BERTopic
 
     # Create your representation model
-    representation_model = OpenAI()
+    representation_model = OpenAI(delay_in_seconds=5)
 
     # Use the representation model in BERTopic on top of the default pipeline
     topic_model = BERTopic(representation_model=representation_model)
@@ -71,8 +95,14 @@ class OpenAI(BaseRepresentation):
     You can also use a custom prompt:
 
     ```python
-    prompt = "I have the following documents: [DOCUMENTS]. What topic do they contain?"
-    representation_model = OpenAI(prompt=prompt)
+    prompt = "I have the following documents: [DOCUMENTS] \nThese documents are about the following topic: '"
+    representation_model = OpenAI(prompt=prompt, delay_in_seconds=5)
+    ```
+
+    If you want to use OpenAI's ChatGPT model:
+    
+    ```python
+    representation_model = OpenAI(model="gpt-3.5-turbo", delay_in_seconds=10, chat=True)
     ```
     """
     def __init__(self,
@@ -80,19 +110,25 @@ class OpenAI(BaseRepresentation):
                  prompt: str = None,
                  generator_kwargs: Mapping[str, Any] = {},
                  delay_in_seconds: float = None,
-
+                 chat: bool = False
                  ):
         self.model = model
-        self.prompt = prompt if prompt is not None else DEFAULT_PROMPT
-        self.default_prompt_ = DEFAULT_PROMPT
+
+        if prompt is None:
+            self.prompt = DEFAULT_CHAT_PROMPT if chat else DEFAULT_PROMPT
+        else:
+            self.prompt = prompt
+
+        self.default_prompt_ = DEFAULT_CHAT_PROMPT if chat else DEFAULT_PROMPT
         self.delay_in_seconds = delay_in_seconds
+        self.chat = chat
 
         self.generator_kwargs = generator_kwargs
         if self.generator_kwargs.get("model"):
             self.model = generator_kwargs.get("model")
         if self.generator_kwargs.get("prompt"):
             del self.generator_kwargs["prompt"]
-        if not self.generator_kwargs.get("stop"):
+        if not self.generator_kwargs.get("stop") and not chat:
             self.generator_kwargs["stop"] = "\n"
 
     def extract_topics(self,
@@ -124,8 +160,18 @@ class OpenAI(BaseRepresentation):
             if self.delay_in_seconds:
                 time.sleep(self.delay_in_seconds)
 
-            response = openai.Completion.create(model=self.model, prompt=prompt, **self.generator_kwargs)
-            label = response["choices"][0]["text"].strip()
+            if self.chat:
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": prompt}
+                ]
+                kwargs = {"model": self.model, "messages": messages, **self.generator_kwargs}
+                response = openai.ChatCompletion.create(**kwargs)
+                label = response["choices"][0]["message"]["content"].strip().replace("topic: ", "")
+            else:
+                response = openai.Completion.create(model=self.model, prompt=prompt, **self.generator_kwargs)
+                label = response["choices"][0]["text"].strip()
+
             updated_topics[topic] = [(label, 1)] + [("", 0) for _ in range(9)]
 
         return updated_topics
@@ -133,22 +179,26 @@ class OpenAI(BaseRepresentation):
     def _create_prompt(self, docs, topic, topics):
         keywords = list(zip(*topics[topic]))[0]
 
-        # Use a prompt that leverages either keywords or documents in
-        # a custom location
-        prompt = ""
-        if "[KEYWORDS]" in self.prompt:
-            prompt += self.prompt.replace("[KEYWORDS]", " ".join(keywords))
-        if "[DOCUMENTS]" in self.prompt:
-            to_replace = ""
-            for doc in docs:
-                to_replace += f"- {doc[:255]}\n"
-            prompt += self.prompt.replace("[DOCUMENTS]", to_replace)
+        # Use the Default Chat Prompt
+        if self.prompt == DEFAULT_CHAT_PROMPT or self.prompt == DEFAULT_PROMPT:
+            prompt = self.prompt.replace("[KEYWORDS]", " ".join(keywords))
+            prompt = self._replace_documents(prompt, docs)
 
-        # Use the default prompt
-        if "[KEYWORDS]" and "[DOCUMENTS]" not in self.prompt:
-            prompt = self.prompt + 'Topic:\nSample texts from this topic:\n'
-            for doc in docs:
-                prompt += f"- {doc[:255]}\n"
-            prompt += "Keywords: " + " ".join(keywords)
-            prompt += "\nTopic name:"
+        # Use a custom prompt that leverages keywords, documents or both using
+        # custom tags, namely [KEYWORDS] and [DOCUMENTS] respectively
+        else:
+            prompt = self.prompt
+            if "[KEYWORDS]" in prompt:
+                prompt = prompt.replace("[KEYWORDS]", " ".join(keywords))
+            if "[DOCUMENTS]" in prompt:
+                prompt = self._replace_documents(prompt, docs)
+
+        return prompt
+
+    @staticmethod
+    def _replace_documents(prompt, docs):
+        to_replace = ""
+        for doc in docs:
+            to_replace += f"- {doc[:255]}\n"
+        prompt = prompt.replace("[DOCUMENTS]", to_replace)
         return prompt

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,79 @@ hide:
 
 # Changelog
 
+## **Version 0.14.1**
+*Release date: 2 March, 2023*
+
+<h3><b>Highlights:</a></b></h3>
+
+* Use [**ChatGPT**](https://maartengr.github.io/BERTopic/getting_started/representation/representation.html#chatgpt) to create topic representations!:
+* Added `delay_in_seconds` parameter to OpenAI and Cohere representation models for throttling the API
+    * Setting this between 5 and 10 allows for trial users now to use more easily without hitting RateLimitErrors
+* Fixed missing `title` param to visualization methods
+* Fixed probabilities not correctly aligning ([#1024](https://github.com/MaartenGr/BERTopic/issues/1024))
+* Fix typo in textgenerator  [@dkopljar27](https://github.com/dkopljar27) in [#1002](https://github.com/MaartenGr/BERTopic/pull/1002)
+
+<h3><b><a href="https://maartengr.github.io/BERTopic/getting_started/representation/representation.html#chatgpt">ChatGPT</a></b></h3>
+
+Within OpenAI's API, the ChatGPT models use a different API structure compared to the GPT-3 models. 
+In order to use ChatGPT with BERTopic, we need to define the model and make sure to set `chat=True`:
+
+```python
+import openai
+from bertopic import BERTopic
+from bertopic.representation import OpenAI
+
+# Create your representation model
+openai.api_key = MY_API_KEY
+representation_model = OpenAI(model="gpt-3.5-turbo", delay_in_seconds=10, chat=True)
+
+# Use the representation model in BERTopic on top of the default pipeline
+topic_model = BERTopic(representation_model=representation_model)
+```
+
+Prompting with ChatGPT is very satisfying and can be customized in BERTopic by using certain tags. 
+There are currently two tags, namely `"[KEYWORDS]"` and `"[DOCUMENTS]"`. 
+These tags indicate where in the prompt they are to be replaced with a topics keywords and top 4 most representative documents respectively. 
+For example, if we have the following prompt:
+
+```python
+prompt = """
+I have topic that contains the following documents: \n[DOCUMENTS]
+The topic is described by the following keywords: [KEYWORDS]
+
+Based on the information above, extract a short topic label in the following format:
+topic: <topic label>
+"""
+```
+
+then that will be rendered as follows and passed to OpenAI's API:
+
+```python
+"""
+I have a topic that contains the following documents: 
+- Our videos are also made possible by your support on patreon.co.
+- If you want to help us make more videos, you can do so on patreon.com or get one of our posters from our shop.
+- If you want to help us make more videos, you can do so there.
+- And if you want to support us in our endeavor to survive in the world of online video, and make more videos, you can do so on patreon.com.
+
+The topic is described by the following keywords: videos video you our support want this us channel patreon make on we if facebook to patreoncom can for and more watch 
+
+Based on the information above, extract a short topic label in the following format:
+topic: <topic label>
+"""
+```
+
+!!! note 
+    Whenever you create a custom prompt, it is important to add 
+    ```
+    Based on the information above, extract a short topic label in the following format:
+    topic: <topic label>
+    ```
+    at the end of your prompt as BERTopic extracts everything that comes after `topic: `. Having 
+    said that, if `topic: ` is not in the output, then it will simply extract the entire response, so 
+    feel free to experiment with the prompts. 
+
+
 ## **Version 0.14.0**
 *Release date: 14 February, 2023*
 

--- a/docs/getting_started/representation/representation.md
+++ b/docs/getting_started/representation/representation.md
@@ -219,8 +219,8 @@ representation_model = TextGeneration('gpt2')
 topic_model = BERTopic(representation_model=representation_model)
 ```
 
-You can use a custom prompt and decide where the keywords should
-be inserted by using the `[KEYWORDS]` or documents with the `[DOCUMENTS]` tag:
+GPT2, however, is not the most accurate model out there on HuggingFace models. You can get 
+much better results with a `flan-T5` like model:
 
 ```python
 from transformers import pipeline
@@ -240,8 +240,8 @@ representation_model = TextGeneration(generator)
 <br>
 
 As can be seen from the example above, if you would like to use a `text2text-generation` model, you will to 
-pass a `transformers.pipeline` with the `"text2text-generation"` parameter. 
-
+pass a `transformers.pipeline` with the `"text2text-generation"` parameter. Moreover, you can use a custom prompt and decide where the keywords should
+be inserted by using the `[KEYWORDS]` or documents with the `[DOCUMENTS]` tag:
 
 ### **Cohere**
 

--- a/docs/getting_started/representation/representation.md
+++ b/docs/getting_started/representation/representation.md
@@ -160,7 +160,7 @@ topic_model = BERTopic(representation_model=representation_model)
 </div>
 <br>
 
-## **Text Generation**
+## **Text Generation & Prompts**
 
 Text generation models, like GPT-3 and the well-known ChatGPT, are becoming more and more capable of generating sensible output. 
 For that purpose, a number of models are exposed in BERTopic that allow topic labels to be created based on candidate documents and keywords
@@ -168,6 +168,34 @@ for each topic. These candidate documents and keywords are created from BERTopic
 describe a topic with only a few documents and we therefore do not need to pass all documents to the text generation model. Not only speeds 
 this the generation of topic labels up significantly, you also do not need a massive amount of credits when using an external API, such as Cohere or OpenAI.
 
+In most of the examples below, we use certain tags to customize our prompts. There are currently two tags, namely `"[KEYWORDS]"` and `"[DOCUMENTS]"`. 
+These tags indicate where in the prompt they are to be replaced with a topics keywords and top 4 most representative documents respectively. 
+For example, if we have the following prompt:
+
+```python
+prompt = """
+I have topic that contains the following documents: \n[DOCUMENTS]
+The topic is described by the following keywords: [KEYWORDS]
+
+Based on the above information, can you give a short label of the topic?
+"""
+```
+
+then that will be rendered as follows:
+
+```python
+"""
+I have a topic that contains the following documents: 
+- Our videos are also made possible by your support on patreon.co.
+- If you want to help us make more videos, you can do so on patreon.com or get one of our posters from our shop.
+- If you want to help us make more videos, you can do so there.
+- And if you want to support us in our endeavor to survive in the world of online video, and make more videos, you can do so on patreon.com.
+
+The topic is described by the following keywords: videos video you our support want this us channel patreon make on we if facebook to patreoncom can for and more watch 
+
+Based on the above information, can you give a short label of the topic?
+"""
+```
 
 !!! tip Tip
     You can access the default prompts of these models with `representation_model.default_prompt_`
@@ -250,7 +278,7 @@ You can also use a custom prompt:
 
 ```python
 prompt = """
-I have topic that contains the following documents: [DOCUMENTS]. 
+I have topic that contains the following documents: [DOCUMENTS]
 The topic is described by the following keywords: [KEYWORDS].
 Based on the above information, can you give a short label of the topic?
 """
@@ -263,7 +291,9 @@ Instead of using a language model from 🤗 transformers, we can use external AP
 do the work for you. Here, we can use [OpenAI](https://openai.com/api/) to extract our topic labels from the candidate documents and keywords.
 To use this, you will need to install openai first:
 
-`pip install openai`
+```bash
+pip install openai
+```
 
 Then, get yourself an API key and use OpenAI's API as follows:
 
@@ -289,9 +319,42 @@ topic_model = BERTopic(representation_model=representation_model)
 You can also use a custom prompt:
 
 ```python
-prompt = "I have the following documents: [DOCUMENTS]. What topic do they contain?"
+prompt = "I have the following documents: [DOCUMENTS] \nThese documents are about the following topic: '"
 representation_model = OpenAI(prompt=prompt)
 ```
+
+#### **ChatGPT**
+
+Within OpenAI's API, the ChatGPT models use a different API structure compared to the GPT-3 models. 
+In order to use ChatGPT with BERTopic, we need to define the model and make sure to enable `chat`:
+
+```python
+representation_model = OpenAI(model="gpt-3.5-turbo", delay_in_seconds=10, chat=True)
+```
+
+Prompting with ChatGPT is very satisfying and is customizable as follows:
+
+```python
+prompt = """
+I have a topic that contains the following documents: 
+[DOCUMENTS]
+The topic is described by the following keywords: [KEYWORDS]
+
+Based on the information above, extract a short topic label in the following format:
+topic: <topic label>
+"""
+```
+
+!!! note 
+    Whenever you create a custom prompt, it is important to add 
+    ```
+    Based on the information above, extract a short topic label in the following format:
+    topic: <topic label>
+    ```
+    at the end of your prompt as BERTopic extracts everything that comes after `topic: `. Having 
+    said that, if `topic: ` is not in the output, then it will simply extract the entire response, so 
+    feel free to experiment with the prompts. 
+
 
 ### **LangChain**
 
@@ -336,7 +399,6 @@ representation_model = LangChain(chain, prompt=prompt)
 !!! note Note
     The prompt does not make use of `[KEYWORDS]` and `[DOCUMENTS]` tags as 
     the documents are already used within langchain's `load_qa_chain`. 
-
 
 ## **Chain Models**
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ with open("README.md", "r") as fh:
 setup(
     name="bertopic",
     packages=find_packages(exclude=["notebooks", "docs"]),
-    version="0.14.0",
+    version="0.14.1",
     author="Maarten P. Grootendorst",
     author_email="maartengrootendorst@gmail.com",
     description="BERTopic performs topic Modeling with state-of-the-art transformer models.",


### PR DESCRIPTION
A few quickfixes for improving prompting and adding support for OpenAI's `"gpt-3.5-turbo"`. 

### Features/Fixes
* Added `delay_in_seconds` parameter to OpenAI and Cohere representation models for throttling the API
  * Setting this between 5 and 10 allows for trial users now to use more easily without hitting RateLimitErrors
* Use ChatGPT as follows:
  * `representation_model = OpenAI(model="gpt-3.5-turbo", chat_completion=True, delay_in_seconds=10)`
* Fixed missing `title` param to visualization methods
* Fixed #1024

### ChatGPT

Within OpenAI's API, the ChatGPT models use a different API structure compared to the GPT-3 models. 
In order to use ChatGPT with BERTopic, we need to define the model and make sure to set `chat=True`:

```python
import openai
from bertopic import BERTopic
from bertopic.representation import OpenAI

# Create your representation model
openai.api_key = MY_API_KEY
representation_model = OpenAI(model="gpt-3.5-turbo", delay_in_seconds=10, chat=True)

# Use the representation model in BERTopic on top of the default pipeline
topic_model = BERTopic(representation_model=representation_model)
```

Prompting with ChatGPT is very satisfying and can be customized in BERTopic by using certain tags. 
There are currently two tags, namely `"[KEYWORDS]"` and `"[DOCUMENTS]"`. 
These tags indicate where in the prompt they are to be replaced with a topics keywords and top 4 most representative documents respectively. 
For example, if we have the following prompt:

```python
prompt = """
I have topic that contains the following documents: \n[DOCUMENTS]
The topic is described by the following keywords: [KEYWORDS]

Based on the information above, extract a short topic label in the following format:
topic: <topic label>
"""
```

then that will be rendered as follows and passed to OpenAI's API:

```python
"""
I have a topic that contains the following documents: 
- Our videos are also made possible by your support on patreon.co.
- If you want to help us make more videos, you can do so on patreon.com or get one of our posters from our shop.
- If you want to help us make more videos, you can do so there.
- And if you want to support us in our endeavor to survive in the world of online video, and make more videos, you can do so on patreon.com.

The topic is described by the following keywords: videos video you our support want this us channel patreon make on we if facebook to patreoncom can for and more watch 

Based on the information above, extract a short topic label in the following format:
topic: <topic label>
"""
```

> **Note**
> Whenever you create a custom prompt, it is important to add 
> ```
> Based on the information above, extract a short topic label in the following format:
> topic: <topic label>
> ```
> at the end of your prompt as BERTopic extracts everything that comes after `topic: `. Having 
> said that, if `topic: ` is not in the output, then it will simply extract the entire response, so 
> feel free to experiment with the prompts. 

