### PR TITLE
Inconsistent naming - get_topic_labels to generate_topic_labels

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -1659,11 +1659,11 @@ class BERTopic:
 
         Examples:
 
-        First, we define our topic labels with `.get_topic_labels` in which
+        First, we define our topic labels with `.generate_topic_labels` in which
         we can customize our topic labels:
 
         ```python
-        topic_labels = topic_model.get_topic_labels(nr_words=2,
+        topic_labels = topic_model.generate_topic_labels(nr_words=2,
                                                     topic_prefix=True,
                                                     word_length=10,
                                                     separator=", ")
@@ -1736,7 +1736,7 @@ class BERTopic:
         To create our custom topic labels, usage is rather straightforward:
 
         ```python
-        topic_labels = topic_model.get_topic_labels(nr_words=2, separator=", ")
+        topic_labels = topic_model.generate_topic_labels(nr_words=2, separator=", ")
         ```
         """
         unique_topics = sorted(set(self.topics_))

--- a/docs/getting_started/topicrepresentation/topicrepresentation.md
+++ b/docs/getting_started/topicrepresentation/topicrepresentation.md
@@ -74,7 +74,7 @@ using the `_` separator. Although this is an informative label, in practice, thi
 `1_space_nasa_orbit` is informative, but we would prefer to have a bit more intuitive label, such as 
 `space travel`. The difficulty with creating such topic labels is that much of the interpretation is left to the user. Would `space travel` be more accurate or perhaps `space explorations`? To truly understand which labels are most suited, going into some of the documents in topics is especially helpful. 
 
-Although we can go through every single topic ourselves and try to label them, we can start by creating an overview of labels that have the length and number of words that we are looking for. To do so, we can generate our list of topic labels with `.get_topic_labels` and define the number of words, the separator, word length, etc:
+Although we can go through every single topic ourselves and try to label them, we can start by creating an overview of labels that have the length and number of words that we are looking for. To do so, we can generate our list of topic labels with `.generate_topic_labels` and define the number of words, the separator, word length, etc:
 
 ```python
 topic_labels = topic_model.generate_topic_labels(nr_words=3,


### PR DESCRIPTION
There has been an inconsistent naming in the documentation between get_topic_labels and generate_topic_labels. All get_topic_labels mentions have been changed to the correct one. (generate_topic_labels)