### PR TITLE
Efficient, faster, and safer serialization with HuggingFace

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Below, you will find an overview of common functions in BERTopic.
 | Reduce nr of topics | `.reduce_topics(docs, nr_topics=30)` |
 | Reduce outliers | `.reduce_outliers(docs, topics)` |
 | Find topics | `.find_topics("vehicle")` |
-| Save model    |  `.save("my_model")` |
+| Save model    |  `.save("my_model", serialization="safetensors")` |
 | Load model    |  `BERTopic.load("my_model")` |
 | Get parameters |  `.get_params()` |
 

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -454,9 +454,9 @@ class BERTopic:
 
         # Transform without hdbscan_model and umap_model using only cosine similarity
         if type(self.hdbscan_model) == BaseCluster:
-            sim_matrix = cosine_similarity(embeddings, self.topic_embeddings_)
+            sim_matrix = cosine_similarity(embeddings, np.array(self.topic_embeddings_))
             predictions = np.argmax(sim_matrix, axis=1) - self._outliers
-            
+
             if self.calculate_probabilities:
                 probabilities = sim_matrix
             else:
@@ -466,7 +466,7 @@ class BERTopic:
         else:
             umap_embeddings = self.umap_model.transform(embeddings)
             logger.info("Reduced dimensionality")
-            
+
             # Extract predictions and probabilities if it is a HDBSCAN-like model
             if is_supported_hdbscan(self.hdbscan_model):
                 predictions, probabilities = hdbscan_delegator(self.hdbscan_model, "approximate_predict", umap_embeddings)
@@ -2749,7 +2749,7 @@ class BERTopic:
 
     def save(self,
              path,
-             serialization: Literal["safetensors", "pickle", "pytorch"],
+             serialization: Literal["safetensors", "pickle", "pytorch"] = "pickle",
              save_embedding_model: Union[bool, str] = True,
              save_ctfidf: bool = False):
         """ Saves the model to the specified path or folder
@@ -3708,11 +3708,11 @@ class TopicMapper:
 
 
 def _create_model_from_files(
-        topics: Mapping[str: Any],
-        params: Mapping[str: Any],
-        tensors: Mapping[str: np.array],
-        ctfidf_tensors: Mapping[str: Any] = None,
-        ctfidf_config: Mapping[str: Any] = None):
+        topics: Mapping[str, Any],
+        params: Mapping[str, Any],
+        tensors: Mapping[str, np.array],
+        ctfidf_tensors: Mapping[str, Any] = None,
+        ctfidf_config: Mapping[str, Any] = None):
     """ Create a BERTopic model from a variety of inputs
 
     Arguments:

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3727,6 +3727,13 @@ def _create_model_from_files(
     from sentence_transformers import SentenceTransformer
     params["n_gram_range"] = tuple(params["n_gram_range"])
 
+    if ctfidf_config is not None:
+        ngram_range = ctfidf_config["vectorizer_model"]["params"]["ngram_range"]
+        ctfidf_config["vectorizer_model"]["params"]["ngram_range"] = tuple(ngram_range)
+
+    params["n_gram_range"] = tuple(params["n_gram_range"])
+    ctfidf_config
+
     # Select HF model through SentenceTransformers
     try:
         embedding_model = select_backend(SentenceTransformer(params['embedding_model']))

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -2813,8 +2813,14 @@ class BERTopic:
                 else:
                     joblib.dump(self, file)
         elif serialization == "safetensors" or serialization == "pytorch":
+
+            # Directory
             save_directory = Path(path)
             save_directory.mkdir(exist_ok=True, parents=True)
+
+            # Check embedding model
+            if save_embedding_model and hasattr(self.embedding_model, '_hf_model') and not isinstance(save_embedding_model, str):
+                save_embedding_model = self.embedding_model._hf_model
 
             # Minimal
             save_utils.save_hf(model=self, save_directory=save_directory, serialization=serialization)

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -2850,11 +2850,11 @@ class BERTopic:
         BERTopic.load("model_dir", embedding_model="all-MiniLM-L6-v2")
         ```
         """
-        path = Path(path)
+        file_or_dir = Path(path)
 
         # Load from Pickle
-        if path.is_file():
-            with open(path, 'rb') as file:
+        if file_or_dir.is_file():
+            with open(file_or_dir, 'rb') as file:
                 if embedding_model:
                     topic_model = joblib.load(file)
                     topic_model.embedding_model = select_backend(embedding_model)
@@ -2863,8 +2863,8 @@ class BERTopic:
                 return topic_model
 
         # Load from directory or HF
-        if path.is_dir():
-            topics, params, tensors, ctfidf_tensors, ctfidf_config = save_utils.load_local_files(path)
+        if file_or_dir.is_dir():
+            topics, params, tensors, ctfidf_tensors, ctfidf_config = save_utils.load_local_files(file_or_dir)
         elif "/" in str(path):
             topics, params, tensors, ctfidf_tensors, ctfidf_config = save_utils.load_files_from_hf(path)
         else:
@@ -2880,7 +2880,7 @@ class BERTopic:
             revision: str = None,
             private: bool = False,
             create_pr: bool = False,
-            model_card: Mapping[str, Any] = None,
+            model_card: bool = True,
             serialization: str = "safetensors",
             save_embedding_model: str = None,
             save_ctfidf: bool = False,
@@ -2910,7 +2910,7 @@ class BERTopic:
             revision: Repository revision
             private: Whether to create a private repository
             create_pr: Whether to upload the model as a Pull Request
-            model_card: Create a model card when creating the repository
+            model_card: Whether to automatically create a modelcard
             serialization: The type of serialization.
                         Either `safetensors` or `pytorch`
             save_embedding_model: A pointer towards a HuggingFace model to be loaded in with

--- a/bertopic/_save_utils.py
+++ b/bertopic/_save_utils.py
@@ -1,0 +1,380 @@
+import os
+import sys
+import json
+import numpy as np
+import scipy.sparse as sp
+
+from pathlib import Path
+from scipy.sparse import csr_matrix
+from tempfile import TemporaryDirectory
+from sklearn.feature_extraction.text import CountVectorizer
+
+from bertopic import BERTopic
+from bertopic.cluster import BaseCluster
+from bertopic.backend import BaseEmbedder
+from bertopic._bertopic import TopicMapper
+from bertopic.backend._utils import select_backend
+from bertopic.dimensionality import BaseDimensionalityReduction
+
+# HuggingFace Hub
+try:
+    from huggingface_hub import (
+        create_repo, get_hf_file_metadata,
+        hf_hub_download, hf_hub_url,
+        repo_type_and_id_from_hf_id, upload_folder)
+    _has_hf_hub = True
+except ImportError:
+    _has_hf_hub = False
+
+# Typing
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+from typing import Union, Mapping, Any
+
+# Safetensors check
+try:
+    import safetensors.torch
+    _has_safetensors = True
+except ImportError:
+    _has_safetensors = False
+
+# Pytorch check
+try:
+    import torch
+    _has_torch = True
+except ImportError:
+    _has_torch = False
+
+TOPICS_NAME = "topics.json"
+CONFIG_NAME = "config.json"
+
+HF_WEIGHTS_NAME = "topic_embeddings.bin"  # default pytorch pkl
+HF_SAFE_WEIGHTS_NAME = "topic_embeddings.safetensors"  # safetensors version
+
+CTFIDF_WEIGHTS_NAME = "ctfidf.bin"  # default pytorch pkl
+CTFIDF_SAFE_WEIGHTS_NAME = "ctfidf.safetensors"  # safetensors version
+CTFIDF_CFG_NAME = "ctfidf_config.json"
+
+
+def push_to_hf_hub(
+        model,
+        repo_id: str,
+        commit_message: str = 'Add BERTopic model',
+        token: str = None,
+        revision: str = None,
+        private: bool = False,
+        create_pr: bool = False,
+        model_card: Mapping[str, Any] = None,
+        serialization: str = "safetensors",
+        save_embedding_model: str = None,
+        save_ctfidf: bool = False,
+        ):
+    """ Push your BERTopic model to a HuggingFace Hub
+
+    Arguments:
+        repo_id: The name of your HuggingFace repository
+        commit_message: A commit message
+        token: Token to add if not already logged in
+        revision: Repository revision
+        private: Whether to create a private repository
+        create_pr: Whether to upload the model as a Pull Request
+        model_card: Create a model card when creating the repository
+        serialization: The type of serialization.
+                       Either `safetensors` or `pytorch`
+        save_embedding_model: A pointer towards a HuggingFace model to be loaded in with
+                                SentenceTransformers. E.g.,
+                                `sentence-transformers/all-MiniLM-L6-v2`
+        save_ctfidf: Whether to save c-TF-IDF information
+    """
+
+    # Create repo if it doesn't exist yet and infer complete repo_id
+    repo_url = create_repo(repo_id, token=token, private=private, exist_ok=True)
+    _, repo_owner, repo_name = repo_type_and_id_from_hf_id(repo_url)
+    repo_id = f"{repo_owner}/{repo_name}"
+
+    # Temporarily save model and push to HF
+    with TemporaryDirectory() as tmpdir:
+
+        # Save model weights and config.
+        model.save(tmpdir, serialization=serialization, save_embedding_model=save_embedding_model, save_ctfidf=save_ctfidf)
+
+        # Add README if it does not exist
+        try:
+            get_hf_file_metadata(hf_hub_url(repo_id=repo_id, filename="README.md", revision=revision))
+        except:
+            model_card = model_card or {}
+            model_name = repo_id.split('/')[-1]
+
+            readme_text = generate_readme(model_card, model_name)
+            readme_path = Path(tmpdir) / "README.md"
+            readme_path.write_text(readme_text)
+
+        # Upload model
+        return upload_folder(repo_id=repo_id, folder_path=tmpdir, revision=revision,
+                             create_pr=create_pr, commit_message=commit_message)
+
+
+def create_model_from_files(
+        topics: Mapping[str: Any],
+        params: Mapping[str: Any],
+        tensors: Mapping[str: np.array],
+        ctfidf_tensors: Mapping[str: Any] = None,
+        ctfidf_config: Mapping[str: Any] = None):
+    """ Create a BERTopic model from a variety of inputs
+
+    Arguments:
+        topics: A dictionary containing topic metadata, including:
+                 - Topic representations, labels, sizes, custom labels, etc.
+        params: BERTopic-specific hyperparams, including HF embedding_model ID
+                if given.
+        tensors: The topic embeddings
+        ctfidf_tensors: The c-TF-IDF representations
+        ctfidf_config: The config for CountVectorizer and c-TF-IDF
+    """
+    from sentence_transformers import SentenceTransformer
+    params["n_gram_range"] = tuple(params["n_gram_range"])
+
+    # Select HF model through SentenceTransformers
+    try:
+        embedding_model = select_backend(SentenceTransformer(params['embedding_model']))
+    except:
+        embedding_model = BaseEmbedder()
+    del params['embedding_model']
+
+    # Prepare our empty sub-models
+    empty_dimensionality_model = BaseDimensionalityReduction()
+    empty_cluster_model = BaseCluster()
+
+    # Fit BERTopic without actually performing any clustering
+    topic_model = BERTopic(
+            embedding_model=embedding_model,
+            umap_model=empty_dimensionality_model,
+            hdbscan_model=empty_cluster_model,
+            **params
+    )
+    topic_model.topic_embeddings_ = tensors["topic_embeddings"].numpy()
+    topic_model.topic_representations_ = {int(key): val for key, val in topics["topic_representations"].items()}
+    topic_model.topics_ = topics["topics"]
+    topic_model.topic_sizes_ = {int(key): val for key, val in topics["topic_sizes"].items()}
+    topic_model.topic_labels_ = {int(key): val for key, val in topics["topic_labels"].items()}
+    topic_model.custom_labels_ = topics["custom_labels"]
+    topic_model._outliers = topics["_outliers"]
+
+    # Topic Mapper
+    topic_model.topic_mapper_ = TopicMapper([0])
+    topic_model.topic_mapper_.mappings_ = topics["topic_mapper"]
+
+    if ctfidf_tensors is not None:
+        topic_model.c_tf_idf_ = csr_matrix((ctfidf_tensors["data"], ctfidf_tensors["indices"], ctfidf_tensors["indptr"]), shape=ctfidf_tensors["shape"])
+
+        # CountVectorizer
+        topic_model.vectorizer_model = CountVectorizer(**ctfidf_config["vectorizer_model"]["params"])
+        topic_model.vectorizer_model.vocabulary_ = ctfidf_config["vectorizer_model"]["vocab"]
+
+        # ClassTfidfTransformer
+        topic_model.ctfidf_model.reduce_frequent_words = ctfidf_config["ctfidf_model"]["reduce_frequent_words"]
+        topic_model.ctfidf_model.bm25_weighting = ctfidf_config["ctfidf_model"]["bm25_weighting"]
+        idf = ctfidf_tensors["diag"].numpy()
+        topic_model.ctfidf_model._idf_diag = sp.diags(idf, offsets=0, shape=(len(idf), len(idf)), format='csr', dtype=np.float64)
+    return topic_model
+
+
+def load_local_files(path):
+    """ Load local BERTopic files """
+    path = path.name
+
+    # Load json configs
+    topics = load_cfg_from_json(path / TOPICS_NAME)
+    params = load_cfg_from_json(path / CONFIG_NAME)
+
+    # Load Topic Embeddings
+    safetensor_path = path / HF_SAFE_WEIGHTS_NAME
+    if safetensor_path.is_file():
+        tensors = safetensors.torch.load_file(safetensor_path, device="cpu")
+    else:
+        torch_path = path / HF_WEIGHTS_NAME
+        if torch_path.is_file():
+            tensors = torch.load(torch_path, map_location="cpu")
+
+    # c-TF-IDF
+    ctfidf_tensors = None
+    safetensor_path = path / CTFIDF_SAFE_WEIGHTS_NAME
+    if safetensor_path.is_file():
+        ctfidf_tensors = safetensors.torch.load_file(safetensor_path, device="cpu")
+    else:
+        torch_path = path / CTFIDF_WEIGHTS_NAME
+        if torch_path.is_file():
+            ctfidf_tensors = torch.load(torch_path, map_location="cpu")
+    ctfidf_config = load_cfg_from_json(path / CTFIDF_CFG_NAME)
+
+    return topics, params, tensors, ctfidf_tensors, ctfidf_config
+
+
+def load_files_from_hf(path):
+    """ Load files from HuggingFace. """
+    path = str(path)
+
+    # Configs
+    topics = load_cfg_from_json(hf_hub_download(path, TOPICS_NAME, revision=None))
+    params = load_cfg_from_json(hf_hub_download(path, CONFIG_NAME, revision=None))
+
+    # Topic Embeddings
+    try:
+        tensors = hf_hub_download(path, HF_SAFE_WEIGHTS_NAME, revision=None)
+        tensors = safetensors.torch.load_file(tensors, device="cpu")
+    except:
+        tensors = hf_hub_download(path, HF_WEIGHTS_NAME, revision=None)
+        tensors = torch.load(tensors, map_location="cpu")
+
+    # c-TF-IDF
+    try:
+        ctfidf_config = load_cfg_from_json(hf_hub_download(path, CTFIDF_CFG_NAME, revision=None))
+        try:
+            ctfidf_tensors = hf_hub_download(path, CTFIDF_SAFE_WEIGHTS_NAME, revision=None)
+            ctfidf_tensors = safetensors.torch.load_file(tensors, device="cpu")
+        except:
+            ctfidf_tensors = hf_hub_download(path, CTFIDF_WEIGHTS_NAME, revision=None)
+            ctfidf_tensors = torch.load(tensors, map_location="cpu")
+    except:
+        ctfidf_config, ctfidf_tensors = None, None
+
+    return topics, params, tensors, ctfidf_tensors, ctfidf_config
+
+
+def generate_readme(model_card: dict, model_name: str):
+    """ Generate README for HuggingFace model card """
+    readme_text = "---\n"
+    readme_text += "tags:\n- image-classification\n- bertopic\n"
+    readme_text += "library_name: bertopic\n"
+    readme_text += f"license: {model_card.get('license', 'mit')}\n"
+    readme_text += "---\n"
+    readme_text += f"# Model card for {model_name}\n"
+
+    if 'description' in model_card:
+        readme_text += f"\n{model_card['description']}\n"
+
+    if 'details' in model_card:
+        readme_text += "\n## Model Details\n\n"
+        for k, v in model_card['details'].items():
+            if isinstance(v, (list, tuple)):
+                readme_text += f"- **{k}:**\n"
+                for vi in v:
+                    readme_text += f"  - {vi}\n"
+            elif isinstance(v, dict):
+                readme_text += f"- **{k}:**\n"
+                for ki, vi in v.items():
+                    readme_text += f"  - {ki}: {vi}\n"
+            else:
+                readme_text += f"- **{k}:** {v}\n"
+
+    if 'usage' in model_card:
+        readme_text += "\n## Model Usage\n"
+        readme_text += model_card['usage']
+        readme_text += '\n'
+
+    return readme_text
+
+
+def save_hf(model, save_directory, serialization: str):
+    """ Save topic embeddings, either safely (using safetensors) or using legacy pytorch """
+    tensors = torch.from_numpy(np.array(model.topic_embeddings_))
+    tensors = {"topic_embeddings": tensors}
+
+    if serialization == "safetensors":
+        assert _has_safetensors, "`pip install safetensors` to use .safetensors"
+        safetensors.torch.save_file(tensors, save_directory / HF_SAFE_WEIGHTS_NAME)
+    if serialization == "pytorch":
+        assert _has_safetensors, "`pip install pytorch` to save as bin"
+        torch.save(tensors, save_directory / HF_WEIGHTS_NAME)
+
+
+def save_ctfidf(model,
+                save_directory: str,
+                serialization: str):
+    """ Save c-TF-IDF sparse matrix """
+    indptr = torch.from_numpy(model.c_tf_idf_.indptr)
+    indices = torch.from_numpy(model.c_tf_idf_.indices)
+    data = torch.from_numpy(model.c_tf_idf_.data)
+    shape = torch.from_numpy(np.array(model.c_tf_idf_.shape))
+    diag = torch.from_numpy(np.array(model.ctfidf_model._idf_diag.data))
+    tensors = {
+        "indptr": indptr,
+        "indices": indices,
+        "data": data,
+        "shape": shape,
+        "diag": diag
+    }
+
+    if serialization == "safetensors":
+        assert _has_safetensors, "`pip install safetensors` to use .safetensors"
+        safetensors.torch.save_file(tensors, save_directory / CTFIDF_SAFE_WEIGHTS_NAME)
+    if serialization == "pytorch":
+        assert _has_safetensors, "`pip install pytorch` to save as .bin"
+        torch.save(tensors, save_directory / CTFIDF_WEIGHTS_NAME)
+
+
+def save_ctfidf_config(model, path):
+    """ Save parameters to recreate CountVectorizer and c-TF-IDF """
+    config = {}
+
+    # Recreate ClassTfidfTransformer
+    config["ctfidf_model"] = {
+        "bm25_weighting": model.ctfidf_model.bm25_weighting,
+        "reduce_frequent_words": model.ctfidf_model.reduce_frequent_words
+    }
+
+    # Recreate CountVectorizer
+    cv_params = model.vectorizer_model.get_params()
+    del cv_params["tokenizer"], cv_params["preprocessor"], cv_params["dtype"]
+    if not isinstance(cv_params["analyzer"], str):
+        del cv_params["analyzer"]
+
+    config["vectorizer_model"] = {
+        "params": cv_params,
+        "vocab": model.vectorizer_model.vocabulary_
+    }
+
+    with path.open('w') as f:
+        json.dump(config, f, indent=2)
+
+
+def save_config(model, path: str, embedding_model):
+    """ Save BERTopic configuration """
+    path = Path(path)
+    params = model.get_params()
+    config = {param: value for param, value in params.items() if "model" not in param}
+
+    # Embedding model tag to be used in sentence-transformers
+    if embedding_model:
+        config["embedding_model"] = embedding_model
+
+    with path.open('w') as f:
+        json.dump(config, f, indent=2)
+
+    return config
+
+
+def save_topics(model, path: str):
+    """ Save Topic-specific information """
+    path = Path(path)
+    topics = {
+        "topic_representations": model.topic_representations_,
+        "topics": model.topics_,
+        "topic_sizes": model.topic_sizes_,
+        "topic_mapper": model.topic_mapper_.mappings_,
+        "topic_labels": model.topic_labels_,
+        "custom_labels": model.custom_labels_,
+        "_outliers": model._outliers
+    }
+
+    with path.open('w') as f:
+        json.dump(topics, f, indent=2)
+
+
+def load_cfg_from_json(json_file: Union[str, os.PathLike]):
+    """ Load configuration from json """
+    with open(json_file, "r", encoding="utf-8") as reader:
+        text = reader.read()
+    return json.loads(text)

--- a/bertopic/_save_utils.py
+++ b/bertopic/_save_utils.py
@@ -212,7 +212,7 @@ def save_hf(model, save_directory, serialization: str):
         assert _has_safetensors, "`pip install safetensors` to use .safetensors"
         safetensors.torch.save_file(tensors, save_directory / HF_SAFE_WEIGHTS_NAME)
     if serialization == "pytorch":
-        assert _has_safetensors, "`pip install pytorch` to save as bin"
+        assert _has_torch, "`pip install pytorch` to save as bin"
         torch.save(tensors, save_directory / HF_WEIGHTS_NAME)
 
 
@@ -237,7 +237,7 @@ def save_ctfidf(model,
         assert _has_safetensors, "`pip install safetensors` to use .safetensors"
         safetensors.torch.save_file(tensors, save_directory / CTFIDF_SAFE_WEIGHTS_NAME)
     if serialization == "pytorch":
-        assert _has_safetensors, "`pip install pytorch` to save as .bin"
+        assert _has_torch, "`pip install pytorch` to save as .bin"
         torch.save(tensors, save_directory / CTFIDF_WEIGHTS_NAME)
 
 

--- a/bertopic/_save_utils.py
+++ b/bertopic/_save_utils.py
@@ -296,7 +296,7 @@ def save_topics(model, path: str):
     }
 
     with path.open('w') as f:
-        json.dump(topics, f, indent=2)
+        json.dump(topics, f, indent=2, cls=NumpyEncoder)
 
 
 def load_cfg_from_json(json_file: Union[str, os.PathLike]):
@@ -304,3 +304,12 @@ def load_cfg_from_json(json_file: Union[str, os.PathLike]):
     with open(json_file, "r", encoding="utf-8") as reader:
         text = reader.read()
     return json.loads(text)
+
+
+class NumpyEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.integer):
+            return int(obj)
+        if isinstance(obj, np.floating):
+            return float(obj)
+        return super(NumpyEncoder, self).default(obj)

--- a/bertopic/_save_utils.py
+++ b/bertopic/_save_utils.py
@@ -2,19 +2,10 @@ import os
 import sys
 import json
 import numpy as np
-import scipy.sparse as sp
 
 from pathlib import Path
-from scipy.sparse import csr_matrix
 from tempfile import TemporaryDirectory
-from sklearn.feature_extraction.text import CountVectorizer
 
-from bertopic import BERTopic
-from bertopic.cluster import BaseCluster
-from bertopic.backend import BaseEmbedder
-from bertopic._bertopic import TopicMapper
-from bertopic.backend._utils import select_backend
-from bertopic.dimensionality import BaseDimensionalityReduction
 
 # HuggingFace Hub
 try:
@@ -114,71 +105,6 @@ def push_to_hf_hub(
         # Upload model
         return upload_folder(repo_id=repo_id, folder_path=tmpdir, revision=revision,
                              create_pr=create_pr, commit_message=commit_message)
-
-
-def create_model_from_files(
-        topics: Mapping[str: Any],
-        params: Mapping[str: Any],
-        tensors: Mapping[str: np.array],
-        ctfidf_tensors: Mapping[str: Any] = None,
-        ctfidf_config: Mapping[str: Any] = None):
-    """ Create a BERTopic model from a variety of inputs
-
-    Arguments:
-        topics: A dictionary containing topic metadata, including:
-                 - Topic representations, labels, sizes, custom labels, etc.
-        params: BERTopic-specific hyperparams, including HF embedding_model ID
-                if given.
-        tensors: The topic embeddings
-        ctfidf_tensors: The c-TF-IDF representations
-        ctfidf_config: The config for CountVectorizer and c-TF-IDF
-    """
-    from sentence_transformers import SentenceTransformer
-    params["n_gram_range"] = tuple(params["n_gram_range"])
-
-    # Select HF model through SentenceTransformers
-    try:
-        embedding_model = select_backend(SentenceTransformer(params['embedding_model']))
-    except:
-        embedding_model = BaseEmbedder()
-    del params['embedding_model']
-
-    # Prepare our empty sub-models
-    empty_dimensionality_model = BaseDimensionalityReduction()
-    empty_cluster_model = BaseCluster()
-
-    # Fit BERTopic without actually performing any clustering
-    topic_model = BERTopic(
-            embedding_model=embedding_model,
-            umap_model=empty_dimensionality_model,
-            hdbscan_model=empty_cluster_model,
-            **params
-    )
-    topic_model.topic_embeddings_ = tensors["topic_embeddings"].numpy()
-    topic_model.topic_representations_ = {int(key): val for key, val in topics["topic_representations"].items()}
-    topic_model.topics_ = topics["topics"]
-    topic_model.topic_sizes_ = {int(key): val for key, val in topics["topic_sizes"].items()}
-    topic_model.topic_labels_ = {int(key): val for key, val in topics["topic_labels"].items()}
-    topic_model.custom_labels_ = topics["custom_labels"]
-    topic_model._outliers = topics["_outliers"]
-
-    # Topic Mapper
-    topic_model.topic_mapper_ = TopicMapper([0])
-    topic_model.topic_mapper_.mappings_ = topics["topic_mapper"]
-
-    if ctfidf_tensors is not None:
-        topic_model.c_tf_idf_ = csr_matrix((ctfidf_tensors["data"], ctfidf_tensors["indices"], ctfidf_tensors["indptr"]), shape=ctfidf_tensors["shape"])
-
-        # CountVectorizer
-        topic_model.vectorizer_model = CountVectorizer(**ctfidf_config["vectorizer_model"]["params"])
-        topic_model.vectorizer_model.vocabulary_ = ctfidf_config["vectorizer_model"]["vocab"]
-
-        # ClassTfidfTransformer
-        topic_model.ctfidf_model.reduce_frequent_words = ctfidf_config["ctfidf_model"]["reduce_frequent_words"]
-        topic_model.ctfidf_model.bm25_weighting = ctfidf_config["ctfidf_model"]["bm25_weighting"]
-        idf = ctfidf_tensors["diag"].numpy()
-        topic_model.ctfidf_model._idf_diag = sp.diags(idf, offsets=0, shape=(len(idf), len(idf)), format='csr', dtype=np.float64)
-    return topic_model
 
 
 def load_local_files(path):

--- a/bertopic/_save_utils.py
+++ b/bertopic/_save_utils.py
@@ -26,7 +26,7 @@ from typing import Union, Mapping, Any
 
 # Safetensors check
 try:
-    import safetensors.torch
+    import safetensors
     _has_safetensors = True
 except ImportError:
     _has_safetensors = False
@@ -159,10 +159,10 @@ def load_files_from_hf(path):
         ctfidf_config = load_cfg_from_json(hf_hub_download(path, CTFIDF_CFG_NAME, revision=None))
         try:
             ctfidf_tensors = hf_hub_download(path, CTFIDF_SAFE_WEIGHTS_NAME, revision=None)
-            ctfidf_tensors = safetensors.torch.load_file(tensors, device="cpu")
+            ctfidf_tensors = safetensors.torch.load_file(ctfidf_tensors, device="cpu")
         except:
             ctfidf_tensors = hf_hub_download(path, CTFIDF_WEIGHTS_NAME, revision=None)
-            ctfidf_tensors = torch.load(tensors, map_location="cpu")
+            ctfidf_tensors = torch.load(ctfidf_tensors, map_location="cpu")
     except:
         ctfidf_config, ctfidf_tensors = None, None
 

--- a/bertopic/backend/_sentencetransformers.py
+++ b/bertopic/backend/_sentencetransformers.py
@@ -37,10 +37,12 @@ class SentenceTransformerBackend(BaseEmbedder):
     def __init__(self, embedding_model: Union[str, SentenceTransformer]):
         super().__init__()
 
+        self._hf_model = None
         if isinstance(embedding_model, SentenceTransformer):
             self.embedding_model = embedding_model
         elif isinstance(embedding_model, str):
             self.embedding_model = SentenceTransformer(embedding_model)
+            self._hf_model = embedding_model
         else:
             raise ValueError("Please select a correct SentenceTransformers model: \n"
                              "`from sentence_transformers import SentenceTransformer` \n"

--- a/bertopic/backend/_utils.py
+++ b/bertopic/backend/_utils.py
@@ -117,9 +117,9 @@ def select_backend(embedding_model,
         try:
             from ._sentencetransformers import SentenceTransformerBackend
             if language.lower() in ["English", "english", "en"]:
-                return SentenceTransformerBackend("all-MiniLM-L6-v2")
+                return SentenceTransformerBackend("sentence-transformers/all-MiniLM-L6-v2")
             elif language.lower() in languages or language == "multilingual":
-                return SentenceTransformerBackend("paraphrase-multilingual-MiniLM-L12-v2")
+                return SentenceTransformerBackend("sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
             else:
                 raise ValueError(f"{language} is currently not supported. However, you can "
                                 f"create any embeddings yourself and pass it through fit_transform(docs, embeddings)\n"
@@ -132,4 +132,4 @@ def select_backend(embedding_model,
             return SklearnEmbedder(pipe)
 
     from ._sentencetransformers import SentenceTransformerBackend
-    return SentenceTransformerBackend("all-MiniLM-L6-v2")
+    return SentenceTransformerBackend("sentence-transformers/all-MiniLM-L6-v2")

--- a/docs/getting_started/quickstart/quickstart.md
+++ b/docs/getting_started/quickstart/quickstart.md
@@ -89,22 +89,59 @@ topic_model.visualize_topics()
 <iframe src="viz.html" style="width:1000px; height: 680px; border: 0px;""></iframe>
 
 ## **Save/Load BERTopic model**
-We can easily save a trained BERTopic model by calling `save`:
+
+There are three methods for saving BERTopic:
+
+1. A light model with `.safetensors` and config files
+2. A light model with pytorch `.bin` and config files
+3. A full model with `.pickle`
+
+Method 3 allows for saving the entire topic model but has several drawbacks:
+
+* Arbitrary code can be run from `.pickle` files
+* The resulting model is rather large (often > 500MB) since all sub-models need to be saved
+* Explicit and specific version control is needed as they typically only run if the environment is exactly the same
+ 
+> **It is advised to use methods 1 or 2 for saving.**
+
+These methods have a number of advantages:
+
+* `.safetensors` is a relatively **safe format**
+* The resulting model can be **very small** (often < 20MB>) since no sub-models need to be saved
+* Although version control is important, there is a bit more **flexibility** with respect to specific versions of packages
+* More easily used in **production**
+* **Share** models with the HuggingFace Hub
+
+
+The methods are as used as follows:
+
 ```python
-from bertopic import BERTopic
-topic_model = BERTopic()
-topic_model.save("my_model")
+topic_model = BERTopic().fit(my_docs)
+
+# Method 1 - safetensors
+embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+topic_model.save("path/to/my/model_dir", serialization="safetensors", save_ctfidf=True, save_embedding_model=embedding_model)
+
+# Method 2 - pytorch
+embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+topic_model.save("path/to/my/model_dir", serialization="pytorch", save_ctfidf=True, save_embedding_model=embedding_model)
+
+# Method 3 - pickle
+topic_model.save("my_model", serialization="pickle")
 ```
 
-Then, we can load the model in one line:
-```python
-topic_model = BERTopic.load("my_model")
-```
+To load a model:
 
-!!! Tip "Tip!"
-    If you do not want to save the embedding model because it is loaded from the cloud, simply run 
-    `model.save("my_model", save_embedding_model=False)` instead. Then, you can load in the model 
-    with `BERTopic.load("my_model", embedding_model="whatever_model_you_used")`. 
+```python
+# Load from directory
+loaded_model = BERTopic.load("path/to/my/model_dir")
+
+# Load from file
+loaded_model = BERTopic.load("my_model")
+
+# Load from HuggingFace
+loaded_model = BERTopic.load("MaartenGr/BERTopic_Wikipedia")
+```
 
 !!! Warning "Warning"
     When saving the model, make sure to also keep track of the versions of dependencies and Python used. 

--- a/docs/getting_started/serialization/serialization.md
+++ b/docs/getting_started/serialization/serialization.md
@@ -1,0 +1,120 @@
+## **Serialization**
+
+Saving, loading, and sharing a BERTopic model can be done in several ways. It is generally advised to go with `.safetensors` as that allows for a small, safe, and fast method for saving your BERTopic model. However, other formats, such as `.pickle` and pytorch `.bin` are also possible.
+
+### **Saving**
+
+There are three methods for saving BERTopic:
+
+1. A light model with `.safetensors` and config files
+2. A light model with pytorch `.bin` and config files
+3. A full model with `.pickle`
+
+Method 3 allows for saving the entire topic model but has several drawbacks:
+
+* Arbitrary code can be run from `.pickle` files
+* The resulting model is rather large (often > 500MB) since all sub-models need to be saved
+* Explicit and specific version control is needed as they typically only run if the environment is exactly the same
+ 
+> **It is advised to use methods 1 or 2 for saving.**
+
+These methods have a number of advantages:
+
+* `.safetensors` is a relatively **safe format**
+* The resulting model can be **very small** (often < 20MB>) since no sub-models need to be saved
+* Although version control is important, there is a bit more **flexibility** with respect to specific versions of packages
+* More easily used in **production**
+* **Share** models with the HuggingFace Hub
+
+The methods are as used as follows:
+
+```python
+topic_model = BERTopic().fit(my_docs)
+
+# Method 1 - safetensors
+embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+topic_model.save("path/to/my/model_dir", serialization="safetensors", save_ctfidf=True, save_embedding_model=embedding_model)
+
+# Method 2 - pytorch
+embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+topic_model.save("path/to/my/model_dir", serialization="pytorch", save_ctfidf=True, save_embedding_model=embedding_model)
+
+# Method 3 - pickle
+topic_model.save("my_model", serialization="pickle")
+```
+
+!!! Warning "Warning"
+    When saving the model, make sure to also keep track of the versions of dependencies and Python used. 
+    Loading and saving the model should be done using the same dependencies and Python. Moreover, models 
+    saved in one version of BERTopic are not guaranteed to load in other versions. 
+
+
+### **HuggingFace Hub**
+
+When you have created a BERTopic model, you can easily share it with other through the HuggingFace Hub.
+
+
+First, you need to log in to your HuggingFace account:
+
+* Log in to your Hugging Face account with the following command:
+
+```bash
+huggingface-cli login
+
+# or using an environment variable
+huggingface-cli login --token $HUGGINGFACE_TOKEN
+```
+
+* Alternatively, you can programmatically login using login() in a notebook or a script:
+
+```python
+from huggingface_hub import login
+login()
+```
+
+* Or you can give a token with the `token` variable
+
+When you have logged in to your HuggingFace account, you can save and upload the model as follows:
+
+```python
+from bertopic import BERTopic
+
+# Train model
+topic_model = BERTopic().fit(my_docs)
+
+# Push to HuggingFace Hub
+topic_model.push_to_hf_hub(
+    repo_id="MaartenGr/BERTopic_ArXiv",
+    save_ctfidf=True
+)
+
+# Load from HuggingFace
+loaded_model = BERTopic.load("MaartenGr/BERTopic_ArXiv")
+```
+
+There are number of parameters that may be worthwile to know:
+
+* `private`
+    * Whether to create a private repository
+* `serialization`
+    * The type of serialization. Either `safetensors` or `pytorch`. Make sure to run `pip install safetensors` for safetensors.
+* `save_embedding_model`
+    * A pointer towards a HuggingFace model to be loaded in with SentenceTransformers. E.g., `sentence-transformers/all-MiniLM-L6-v2`
+* `save_ctfidf`
+    * Whether to save c-TF-IDF information
+
+
+### **Loading**
+
+To load a model:
+
+```python
+# Load from directory
+loaded_model = BERTopic.load("path/to/my/model_dir")
+
+# Load from file
+loaded_model = BERTopic.load("my_model")
+
+# Load from HuggingFace
+loaded_model = BERTopic.load("MaartenGr/BERTopic_Wikipedia")
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,7 +135,7 @@ Below, you will find an overview of common functions in BERTopic.
 | Reduce nr of topics | `.reduce_topics(docs, nr_topics=30)` |
 | Reduce outliers | `.reduce_outliers(docs, topics)` |
 | Find topics | `.find_topics("vehicle")` |
-| Save model    |  `.save("my_model")` |
+| Save model    |  `.save("my_model", serialization="safetensors")` |
 | Load model    |  `BERTopic.load("my_model")` |
 | Get parameters |  `.get_params()` |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - Search Topics: getting_started/search/search.md
       - Parameter tuning: getting_started/parameter tuning/parametertuning.md       
       - Outlier reduction: getting_started/outlier_reduction/outlier_reduction.md       
+      - Serialization: getting_started/serialization/serialization.md       
       - Tips & Tricks: getting_started/tips_and_tricks/tips_and_tricks.md       
       - Sub-models:
         - Embeddings: getting_started/embeddings/embeddings.md

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3,7 +3,7 @@ from bertopic import BERTopic
 
 def test_load_save_model():
     model = BERTopic(language="Dutch", embedding_model=None)
-    model.save("test")
+    model.save("test", serialization="pickle")
     loaded_model = BERTopic.load("test")
     assert type(model) == type(loaded_model)
     assert model.language == loaded_model.language


### PR DESCRIPTION
# Efficient Saving with HuggingFace

Through a great collaboration with HuggingFace and the [BERTransfer](https://github.com/opinionscience/BERTransfer) initiative, a set of features aimed at efficiently saving, loading, and using BERTopic.  

The underlying idea is that the modularity of BERTopic allows it to remove the dimensionality and clustering models **after** fitting BERTopic as transforming unseen documents to topics can be done by comparing document embeddings with topic embeddings. Moreover, many embedding models are already on the HuggingFace Hub, so only pointers are necessary to be saved. 

As a result, we can compress a BERTopic model from ~500MB to only ~5MB by only needing to save the following things:
* Pointer to the embedding model (e.g., "sentence-transformers/all-MiniLM-L6-v2")
* Topic representations (topics, topic labels, custom labels, topic sizes, etc.)
* BERTopic hyperparameters
* c-TF-IDF matrix

All of the above can be saved quite efficiently and is all that is necessary to reproduce a BERTopic model. As a result, there are a bunch of new functionalities and advantages with BERTopic, especially from a production setting:

* Nearly **all functionality** of BERTopic is kept
* Create **small** BERTopic models
   * Training on millions of documents would only result in a model of around 20MB-50MB!
* **Easily share** models as they are quite small
  * Sharing with **HuggingFace Hub** is now also possible 
* **Backwards compatible** from this version onwards
* More easily used in **production**
* Save BERTopic **safely** with **safetensors**
> **NOTE:** You can find an example of a pre-trained BERTopic model [here](https://huggingface.co/MaartenGr/BERTopic_ArXiv)

## HuggingFace Hub


```python
from bertopic import BERTopic

# Train model
topic_model = BERTopic().fit(my_docs)

# Push to HuggingFace Hub
topic_model.push_to_hf_hub(
    repo_id="MaartenGr/BERTopic_ArXiv",
    save_ctfidf=True,
    save_embedding_model="sentence-transformers/all-MiniLM-L6-v2"
)

# Load from HuggingFace
loaded_model = BERTopic.load("MaartenGr/BERTopic_ArXiv")
```

## Local Saving


```python
from bertopic import BERTopic

# Train model
topic_model = BERTopic().fit(my_docs)

# Save locally as safetensor with c-TF-IDF and a pointer to an embedding model
embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
topic_model.save("model_dir", serialization="safetensors", save_ctfidf=True, save_embedding_model=embedding_model)

# Load from local dir
loaded_model = BERTopic.load("model_dir")
```

### To do
* Update topic embeddings to be centroids as they are typically more accurate for inference (less so for representation purposes)
  * Additionally, since c-TF-IDF can capture domain-specific data more easily, also use c-TF-IDF to perform inference (or give the option to do so) 
  * The old topic embeddings, weighted average of c-TF-IDF word embeddings, can perhaps still be kept for representation purposes (e.g., comparing topic representations)