### PR TITLE
Add pipeline_tag to model card 

### DIFF
--- a/bertopic/_save_utils.py
+++ b/bertopic/_save_utils.py
@@ -54,6 +54,7 @@ MODEL_CARD_TEMPLATE = """
 tags:
 - bertopic
 library_name: bertopic
+pipeline_tag: text-classification
 ---
 
 # {MODEL_NAME}


### PR DESCRIPTION
The `pipeline_tag` is used on the Hugging Face hub to determine what tasks a model supports. This determines which inference API/widget is used for the model. 