### PR TITLE
convert y to numpy array in _reduce_dimensionality

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3180,7 +3180,8 @@ class BERTopic:
         # Regular fit
         else:
             try:
-                self.umap_model.fit(embeddings, y=y)
+                # cuml umap needs y to be an numpy array
+                self.umap_model.fit(embeddings, y=np.array(y))
             except TypeError:
                 logger.info("The dimensionality reduction algorithm did not contain the `y` parameter and"
                             " therefore the `y` parameter was not used")


### PR DESCRIPTION
When using cuml umap, y needs to be a numpy array instead of a list.

Here's another one I didn't check first before fixing :laughing: 

this will fix #1241 

I leave y as a list everywhere, since I saw at least a few type hints that specified y could be a list or a numpy array. I don't know the intention there, so I only convert it to a numpy array in the _reduce_dimensionality function instead.