### PR TITLE
Allow retrying on Service Unavailable errors from OpenAI

### DIFF
--- a/bertopic/representation/_openai.py
+++ b/bertopic/representation/_openai.py
@@ -229,8 +229,20 @@ class OpenAI(BaseRepresentation):
 
 
 def completions_with_backoff(**kwargs):
-    return retry_with_exponential_backoff(openai.Completion.create, errors=(openai.error.RateLimitError,))(**kwargs)
+    return retry_with_exponential_backoff(
+        openai.Completion.create,
+        errors=(
+            openai.error.RateLimitError,
+            openai.error.ServiceUnavailableError,
+        ),
+    )(**kwargs)
 
 
 def chat_completions_with_backoff(**kwargs):
-    return retry_with_exponential_backoff(openai.ChatCompletion.create, errors=(openai.error.RateLimitError,))(**kwargs)
+    return retry_with_exponential_backoff(
+        openai.ChatCompletion.create,
+        errors=(
+            openai.error.RateLimitError,
+            openai.error.ServiceUnavailableError,
+        ),
+    )(**kwargs)


### PR DESCRIPTION
OpenAI is fairly unreliable in my experience and often returns ServiceUnavailable errors.

Eg:
- https://community.openai.com/t/i-have-the-error-openai-error-serviceunavailableerror-the-server-is-overloaded-or-not-ready-yet/290475
- https://community.openai.com/t/gpt-3-5-turbo-the-server-is-overloaded-or-not-ready-yet-errors/283196
- https://community.openai.com/t/continuous-server-overloaded-error-when-attempting-to-google-via-auto-gpt-paid-account/267802

This PR allows backoff and retry in response to these errors. 