### PR TITLE
Add new line to fix markdown bullet point formatting

### DIFF
--- a/docs/getting_started/outlier_reduction/outlier_reduction.md
+++ b/docs/getting_started/outlier_reduction/outlier_reduction.md
@@ -27,7 +27,8 @@ new_topics = topic_model.reduce_outliers(docs, topics)
 The default method for reducing outliers is by calculating the c-TF-IDF representations of outlier documents and assigning them 
 to the best matching c-TF-IDF representations of non-outlier topics. 
 
-However, there are a number of other strategies one can use, either seperately or in conjunction that are worthwhile to explore:
+However, there are a number of other strategies one can use, either separately or in conjunction that are worthwhile to explore:
+
 * Using the topic-document probabilities to assign topics
 * Using the topic-document distributions to assign topics
 * Using c-TF-IDF representations to assign topics


### PR DESCRIPTION
Fixes the bullet point formatting which is [currently displayed as follows](https://maartengr.github.io/BERTopic/getting_started/outlier_reduction/outlier_reduction.html):

<img width="792" alt="image" src="https://github.com/MaartenGr/BERTopic/assets/13351748/0e4a15ca-6b6b-4e93-9db3-e27a52a3abff">
