### PR TITLE
Update topicrepresentation.md

### DIFF
--- a/docs/getting_started/topicrepresentation/topicrepresentation.md
+++ b/docs/getting_started/topicrepresentation/topicrepresentation.md
@@ -59,7 +59,7 @@ instead:
 
 ```python
 from sklearn.feature_extraction.text import CountVectorizer
-vectorizer_model = CountVectorizer(stop_words="English", ngram_range=(1, 5))
+vectorizer_model = CountVectorizer(stop_words="english", ngram_range=(1, 5))
 topic_model.update_topics(docs, vectorizer_model=vectorizer_model)
 ```
 


### PR DESCRIPTION
I get the following error when "english" is not lowercase:

raise InvalidParameterError(
sklearn.utils._param_validation.InvalidParameterError: The 'stop_words' parameter of CountVectorizer must be a str among {'english'}, an instance of 'list' or None. Got 'English' instead.