### PR TITLE
Add params to truncate documents to length when using LLMs

### DIFF
--- a/bertopic/representation/_cohere.py
+++ b/bertopic/representation/_cohere.py
@@ -122,6 +122,7 @@ class Cohere(BaseRepresentation):
         self.diversity = diversity
         self.doc_length = doc_length
         self.tokenizer = tokenizer
+        self.prompts_ = []
 
     def extract_topics(self,
                        topic_model,
@@ -148,6 +149,7 @@ class Cohere(BaseRepresentation):
         for topic, docs in tqdm(repr_docs_mappings.items(), disable=not topic_model.verbose):
             truncated_docs = [truncate_document(topic_model, self.doc_length, self.tokenizer, doc) for doc in docs]
             prompt = self._create_prompt(truncated_docs, topic, topics)
+            self.prompts_.append(prompt)
 
             # Delay
             if self.delay_in_seconds:

--- a/bertopic/representation/_cohere.py
+++ b/bertopic/representation/_cohere.py
@@ -168,7 +168,7 @@ class Cohere(BaseRepresentation):
 
         # Use the Default Chat Prompt
         if self.prompt == DEFAULT_PROMPT:
-            prompt = self.prompt.replace("[KEYWORDS]", " ".join(keywords))
+            prompt = self.prompt.replace("[KEYWORDS]", ", ".join(keywords))
             prompt = self._replace_documents(prompt, docs)
 
         # Use a custom prompt that leverages keywords, documents or both using
@@ -176,7 +176,7 @@ class Cohere(BaseRepresentation):
         else:
             prompt = self.prompt
             if "[KEYWORDS]" in prompt:
-                prompt = prompt.replace("[KEYWORDS]", " ".join(keywords))
+                prompt = prompt.replace("[KEYWORDS]", ", ".join(keywords))
             if "[DOCUMENTS]" in prompt:
                 prompt = self._replace_documents(prompt, docs)
 

--- a/bertopic/representation/_openai.py
+++ b/bertopic/representation/_openai.py
@@ -160,6 +160,7 @@ class OpenAI(BaseRepresentation):
         self.diversity = diversity
         self.doc_length = doc_length
         self.tokenizer = tokenizer
+        self.prompts_ = []
 
         self.generator_kwargs = generator_kwargs
         if self.generator_kwargs.get("model"):
@@ -194,6 +195,7 @@ class OpenAI(BaseRepresentation):
         for topic, docs in tqdm(repr_docs_mappings.items(), disable=not topic_model.verbose):
             truncated_docs = [truncate_document(topic_model, self.doc_length, self.tokenizer, doc) for doc in docs]
             prompt = self._create_prompt(truncated_docs, topic, topics)
+            self.prompts_.append(prompt)
 
             # Delay
             if self.delay_in_seconds:

--- a/bertopic/representation/_openai.py
+++ b/bertopic/representation/_openai.py
@@ -1,10 +1,11 @@
 import time
 import openai
 import pandas as pd
+from tqdm import tqdm
 from scipy.sparse import csr_matrix
-from typing import Mapping, List, Tuple, Any
+from typing import Mapping, List, Tuple, Any, Union, Callable
 from bertopic.representation._base import BaseRepresentation
-from bertopic.representation._utils import retry_with_exponential_backoff
+from bertopic.representation._utils import retry_with_exponential_backoff, truncate_document
 
 
 DEFAULT_PROMPT = """
@@ -47,13 +48,13 @@ topic: <topic label>
 
 class OpenAI(BaseRepresentation):
     """ Using the OpenAI API to generate topic labels based
-    on one of their Completion of ChatCompletion models. 
+    on one of their Completion of ChatCompletion models.
 
-    The default method is `openai.Completion` if `chat=False`. 
-    The prompts will also need to follow a completion task. If you 
+    The default method is `openai.Completion` if `chat=False`.
+    The prompts will also need to follow a completion task. If you
     are looking for a more interactive chats, use `chat=True`
-    with `model=gpt-3.5-turbo`. 
-    
+    with `model=gpt-3.5-turbo`.
+
     For an overview see:
     https://platform.openai.com/docs/models
 
@@ -83,6 +84,21 @@ class OpenAI(BaseRepresentation):
                    Accepts values between 0 and 1. A higher 
                    values results in passing more diverse documents
                    whereas lower values passes more similar documents.
+        doc_length: The maximum length of each document. If a document is longer,
+                    it will be truncated. If None, the entire document is passed.
+        tokenizer: The tokenizer used to calculate to split the document into segments
+                   used to count the length of a document. 
+                       * If tokenizer is 'char', then the document is split up 
+                         into characters which are counted to adhere to `doc_length`
+                       * If tokenizer is 'whitespace', the the document is split up
+                         into words separated by whitespaces. These words are counted
+                         and truncated depending on `doc_length`
+                       * If tokenizer is 'vectorizer', then the internal CountVectorizer
+                         is used to tokenize the document. These tokens are counted
+                         and trunctated depending on `doc_length`
+                       * If tokenizer is a callable, then that callable is used to tokenize
+                         the document. These tokens are counted and truncated depending
+                         on `doc_length`
 
     Usage:
 
@@ -112,7 +128,7 @@ class OpenAI(BaseRepresentation):
     ```
 
     If you want to use OpenAI's ChatGPT model:
-    
+
     ```python
     representation_model = OpenAI(model="gpt-3.5-turbo", delay_in_seconds=10, chat=True)
     ```
@@ -125,10 +141,12 @@ class OpenAI(BaseRepresentation):
                  exponential_backoff: bool = False,
                  chat: bool = False,
                  nr_docs: int = 4,
-                 diversity: float = None
+                 diversity: float = None,
+                 doc_length: int = None,
+                 tokenizer: Union[str, Callable] = None
                  ):
         self.model = model
-        
+
         if prompt is None:
             self.prompt = DEFAULT_CHAT_PROMPT if chat else DEFAULT_PROMPT
         else:
@@ -140,6 +158,8 @@ class OpenAI(BaseRepresentation):
         self.chat = chat
         self.nr_docs = nr_docs
         self.diversity = diversity
+        self.doc_length = doc_length
+        self.tokenizer = tokenizer
 
         self.generator_kwargs = generator_kwargs
         if self.generator_kwargs.get("model"):
@@ -171,15 +191,16 @@ class OpenAI(BaseRepresentation):
 
         # Generate using OpenAI's Language Model
         updated_topics = {}
-        for topic, docs in repr_docs_mappings.items():
-            prompt = self._create_prompt(docs, topic, topics)
+        for topic, docs in tqdm(repr_docs_mappings.items(), disable=not topic_model.verbose):
+            truncated_docs = [truncate_document(topic_model, self.doc_length, self.tokenizer, doc) for doc in docs]
+            prompt = self._create_prompt(truncated_docs, topic, topics)
 
             # Delay
             if self.delay_in_seconds:
                 time.sleep(self.delay_in_seconds)
 
             if self.chat:
-                messages=[
+                messages = [
                     {"role": "system", "content": "You are a helpful assistant."},
                     {"role": "user", "content": prompt}
                 ]
@@ -223,7 +244,7 @@ class OpenAI(BaseRepresentation):
     def _replace_documents(prompt, docs):
         to_replace = ""
         for doc in docs:
-            to_replace += f"- {doc[:255]}\n"
+            to_replace += f"- {doc}\n"
         prompt = prompt.replace("[DOCUMENTS]", to_replace)
         return prompt
 

--- a/bertopic/representation/_openai.py
+++ b/bertopic/representation/_openai.py
@@ -226,7 +226,7 @@ class OpenAI(BaseRepresentation):
 
         # Use the Default Chat Prompt
         if self.prompt == DEFAULT_CHAT_PROMPT or self.prompt == DEFAULT_PROMPT:
-            prompt = self.prompt.replace("[KEYWORDS]", " ".join(keywords))
+            prompt = self.prompt.replace("[KEYWORDS]", ", ".join(keywords))
             prompt = self._replace_documents(prompt, docs)
 
         # Use a custom prompt that leverages keywords, documents or both using
@@ -234,7 +234,7 @@ class OpenAI(BaseRepresentation):
         else:
             prompt = self.prompt
             if "[KEYWORDS]" in prompt:
-                prompt = prompt.replace("[KEYWORDS]", " ".join(keywords))
+                prompt = prompt.replace("[KEYWORDS]", ", ".join(keywords))
             if "[DOCUMENTS]" in prompt:
                 prompt = self._replace_documents(prompt, docs)
 

--- a/bertopic/representation/_textgeneration.py
+++ b/bertopic/representation/_textgeneration.py
@@ -3,8 +3,9 @@ from tqdm import tqdm
 from scipy.sparse import csr_matrix
 from transformers import pipeline, set_seed
 from transformers.pipelines.base import Pipeline
-from typing import Mapping, List, Tuple, Any, Union
+from typing import Mapping, List, Tuple, Any, Union, Callable
 from bertopic.representation._base import BaseRepresentation
+from bertopic.representation._utils import truncate_document
 
 
 DEFAULT_PROMPT = """
@@ -32,9 +33,24 @@ class TextGeneration(BaseRepresentation):
         nr_docs: The number of documents to pass to OpenAI if a prompt
                  with the `["DOCUMENTS"]` tag is used.
         diversity: The diversity of documents to pass to OpenAI.
-                   Accepts values between 0 and 1. A higher 
+                   Accepts values between 0 and 1. A higher
                    values results in passing more diverse documents
                    whereas lower values passes more similar documents.
+        doc_length: The maximum length of each document. If a document is longer,
+                    it will be truncated. If None, the entire document is passed.
+        tokenizer: The tokenizer used to calculate to split the document into segments
+                   used to count the length of a document.
+                       * If tokenizer is 'char', then the document is split up
+                         into characters which are counted to adhere to `doc_length`
+                       * If tokenizer is 'whitespace', the the document is split up
+                         into words separated by whitespaces. These words are counted
+                         and truncated depending on `doc_length`
+                       * If tokenizer is 'vectorizer', then the internal CountVectorizer
+                         is used to tokenize the document. These tokens are counted
+                         and trunctated depending on `doc_length`
+                       * If tokenizer is a callable, then that callable is used to tokenize
+                         the document. These tokens are counted and truncated depending
+                         on `doc_length`
 
     Usage:
 
@@ -71,7 +87,10 @@ class TextGeneration(BaseRepresentation):
                  pipeline_kwargs: Mapping[str, Any] = {},
                  random_state: int = 42,
                  nr_docs: int = 4,
-                 diversity: float = None):
+                 diversity: float = None,
+                 doc_length: int = None,
+                 tokenizer: Union[str, Callable] = None
+                 ):
         set_seed(random_state)
         if isinstance(model, str):
             self.model = pipeline("text-generation", model=model)
@@ -86,6 +105,8 @@ class TextGeneration(BaseRepresentation):
         self.pipeline_kwargs = pipeline_kwargs
         self.nr_docs = nr_docs
         self.diversity = diversity
+        self.doc_length = doc_length
+        self.tokenizer = tokenizer
 
     def extract_topics(self,
                        topic_model,
@@ -106,15 +127,23 @@ class TextGeneration(BaseRepresentation):
         """
         # Extract the top 4 representative documents per topic
         if self.prompt != DEFAULT_PROMPT and "[DOCUMENTS]" in self.prompt:
-            repr_docs_mappings, _, _, _ = topic_model._extract_representative_docs(c_tf_idf, documents, topics, 500, self.nr_docs, self.diversity)
+            repr_docs_mappings, _, _, _ = topic_model._extract_representative_docs(
+                c_tf_idf,
+                documents,
+                topics,
+                500,
+                self.nr_docs,
+                self.diversity
+            )
         else:
             repr_docs_mappings = {topic: None for topic in topics.keys()}
 
         updated_topics = {}
-        for topic, _ in tqdm(topics.items(), disable=not topic_model.verbose):
+        for topic, docs in tqdm(repr_docs_mappings.items(), disable=not topic_model.verbose):
 
             # Prepare prompt
-            prompt = self._create_prompt(repr_docs_mappings[topic], topic, topics)
+            truncated_docs = [truncate_document(topic_model, self.doc_length, self.tokenizer, doc) for doc in docs]
+            prompt = self._create_prompt(truncated_docs, topic, topics)
 
             # Extract result from generator and use that as label
             topic_description = self.model(prompt, **self.pipeline_kwargs)
@@ -143,7 +172,7 @@ class TextGeneration(BaseRepresentation):
             if "[DOCUMENTS]" in prompt:
                 to_replace = ""
                 for doc in docs:
-                    to_replace += f"- {doc[:255]}\n"
+                    to_replace += f"- {doc}\n"
                 prompt = prompt.replace("[DOCUMENTS]", to_replace)
 
         return prompt

--- a/bertopic/representation/_textgeneration.py
+++ b/bertopic/representation/_textgeneration.py
@@ -108,6 +108,8 @@ class TextGeneration(BaseRepresentation):
         self.doc_length = doc_length
         self.tokenizer = tokenizer
 
+        self.prompts_ = []
+
     def extract_topics(self,
                        topic_model,
                        documents: pd.DataFrame,
@@ -144,6 +146,7 @@ class TextGeneration(BaseRepresentation):
             # Prepare prompt
             truncated_docs = [truncate_document(topic_model, self.doc_length, self.tokenizer, doc) for doc in docs]
             prompt = self._create_prompt(truncated_docs, topic, topics)
+            self.prompts_.append(prompt)
 
             # Extract result from generator and use that as label
             topic_description = self.model(prompt, **self.pipeline_kwargs)

--- a/bertopic/representation/_utils.py
+++ b/bertopic/representation/_utils.py
@@ -1,6 +1,50 @@
 import random
 import time
 
+
+def truncate_document(topic_model, doc_length, tokenizer, document: str):
+    """ Truncate a document to a certain length
+
+    Arguments:
+        topic_model: A BERTopic model
+        doc_length: The maximum length of each document. If a document is longer,
+                    it will be truncated. If None, the entire document is passed.
+        tokenizer: The tokenizer used to calculate to split the document into segments
+                   used to count the length of a document. 
+                       * If tokenizer is 'char', then the document is split up 
+                         into characters which are counted to adhere to `doc_length`
+                       * If tokenizer is 'whitespace', the the document is split up
+                         into words separated by whitespaces. These words are counted
+                         and truncated depending on `doc_length`
+                       * If tokenizer is 'vectorizer', then the internal CountVectorizer
+                         is used to tokenize the document. These tokens are counted
+                         and trunctated depending on `doc_length`. They are decoded with 
+                         whitespaces.
+                       * If tokenizer is a callable, then that callable is used to tokenize
+                         the document. These tokens are counted and truncated depending
+                         on `doc_length`
+        document: A single document
+
+    Returns:
+        truncated_document: A truncated document
+    """
+    if doc_length is not None:
+        if tokenizer == "char":
+            truncated_document = document[:doc_length]
+        elif tokenizer == "whitespace":
+            truncated_document = " ".join(document.split()[:doc_length])
+        elif tokenizer == "vectorizer":
+            tokenizer = topic_model.vectorizer_model.build_tokenizer()
+            truncated_document = " ".join(tokenizer(document)[:doc_length])
+        elif hasattr(tokenizer, 'encode') and hasattr(tokenizer, 'decode'):
+            encoded_document = tokenizer.encode(document)
+            truncated_document = tokenizer.decode(encoded_document[:doc_length])
+        elif isinstance(tokenizer, str):
+            truncated_document = f"{tokenizer}".join(document.split(tokenizer)[:doc_length])
+        return truncated_document
+    return document
+
+
 def retry_with_exponential_backoff(
     func,
     initial_delay: float = 1,

--- a/bertopic/representation/_utils.py
+++ b/bertopic/representation/_utils.py
@@ -5,6 +5,21 @@ import time
 def truncate_document(topic_model, doc_length, tokenizer, document: str):
     """ Truncate a document to a certain length
 
+    If you want to add a custom tokenizer, then it will need to have a `decode` and
+    `encode` method. An example would be the following custom tokenizer:
+
+    ```python
+    class Tokenizer:
+        'A custom tokenizer that splits on commas'
+        def encode(self, doc):
+            return doc.split(",")
+
+        def decode(self, doc_chuncks):
+            return ",".join(doc_chuncks)
+    ```
+
+    You can use this tokenizer by passing it to the `tokenizer` parameter.
+
     Arguments:
         topic_model: A BERTopic model
         doc_length: The maximum length of each document. If a document is longer,
@@ -39,8 +54,6 @@ def truncate_document(topic_model, doc_length, tokenizer, document: str):
         elif hasattr(tokenizer, 'encode') and hasattr(tokenizer, 'decode'):
             encoded_document = tokenizer.encode(document)
             truncated_document = tokenizer.decode(encoded_document[:doc_length])
-        elif isinstance(tokenizer, str):
-            truncated_document = f"{tokenizer}".join(document.split(tokenizer)[:doc_length])
         return truncated_document
     return document
 

--- a/docs/getting_started/representation/llm.md
+++ b/docs/getting_started/representation/llm.md
@@ -5,7 +5,7 @@ Using these techniques, we can further fine-tune topics to generate labels, summ
 A huge benefit of this is that we can describe a topic with only a few documents and we therefore do not need to pass all documents to the text generation model. Not only speeds this the generation of topic labels up significantly, you also do not need a massive amount of credits when using an external API, such as Cohere or OpenAI.
 
 
-## **Prompts**
+## **Prompt Engineering**
 
 In most of the examples below, we use certain tags to customize our prompts. There are currently two tags, namely `"[KEYWORDS]"` and `"[DOCUMENTS]"`. 
 These tags indicate where in the prompt they are to be replaced with a topics keywords and top 4 most representative documents respectively. 
@@ -38,6 +38,56 @@ Based on the above information, can you give a short label of the topic?
 
 !!! tip Tip
     You can access the default prompts of these models with `representation_model.default_prompt_`
+
+
+### **Document Truncation**
+
+We can truncate the input documents in `[DOCUMENTS]` in order to reduce the number of tokens that we have in our input prompt. To do so, all text generation modules have two parameters that we can tweak:
+
+* `doc_length`
+    * The maximum length of each document. If a document is longer, it will be truncated. If None, the entire document is passed.
+* `tokenizer`
+    * The tokenizer used to calculate to split the document into segments used to count the length of a document. 
+        * If tokenizer is  `'char'`, then the document is split up into characters which are counted to adhere to `doc_length`
+        * If tokenizer is `'whitespace'`, the the document is split up into words separated by whitespaces. These words are counted       and truncated depending on `doc_length`
+        * If tokenizer is `'vectorizer'`, then the internal CountVectorizer is used to tokenize the document. These tokens are counted and trunctated depending on `doc_length`
+        * If tokenizer is a callable, then that callable is used to tokenized the document. These tokens are counted and truncated depending on `doc_length`
+
+This means that the definition of `doc_length` changes depending on what constitutes a token in the `tokenizer` parameter. If a token is a character, then `doc_length` refers to max length in characters. If a token is a word, then `doc_length` refers to the max length in words.
+
+Let's illustrate this with an example. In the code below, we will use [`tiktoken`](https://github.com/openai/tiktoken) to count the number of tokens in each document and limit them to 100 tokens. All documents that have more than 100 tokens will be truncated.
+
+We start by installing the relevant packages:
+
+```bash
+pip install tiktoken openai
+```
+
+Then, we use `bertopic.representation.OpenAI` to represent our topics with nicely written labels. We specify that documents that we put in the prompt cannot exceed 100 tokens each. Since we will put 4 documents in the prompt, they will total roughly 400 tokens:
+
+```python
+import openai
+import tiktoken
+from bertopic.representation import OpenAI
+from bertopic import BERTopic
+
+# Tokenizer
+tokenizer= tiktoken.encoding_for_model("gpt-3.5-turbo")
+
+# Create your representation model
+openai.api_key = MY_API_KEY
+representation_model = OpenAI(
+    model="gpt-3.5-turbo", 
+    delay_in_seconds=2, 
+    chat=True,
+    nr_docs=4,
+    doc_length=100,
+    tokenizer=tokenizer
+)
+
+# Use the representation model in BERTopic on top of the default pipeline
+topic_model = BERTopic(representation_model=representation_model)
+```
 
 ## **🤗 Transformers**
 
@@ -81,6 +131,111 @@ representation_model = TextGeneration(generator)
 As can be seen from the example above, if you would like to use a `text2text-generation` model, you will to 
 pass a `transformers.pipeline` with the `"text2text-generation"` parameter. Moreover, you can use a custom prompt and decide where the keywords should
 be inserted by using the `[KEYWORDS]` or documents with the `[DOCUMENTS]` tag:
+
+### **Llama 2**
+
+Full Llama 2 Tutorial: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1QCERSMUjqGetGGujdrvv_6_EeoIcd_9M?usp=sharing)
+
+Open-source LLMs are starting to become more and more popular. Here, we will go through a minimal example of using [Llama 2](https://huggingface.co/meta-llama/Llama-2-13b-chat-hf) together with BERTopic. 
+
+First, we need to load in our Llama 2 model:
+
+```python
+from torch import bfloat16
+import transformers
+
+# set quantization configuration to load large model with less GPU memory
+# this requires the `bitsandbytes` library
+bnb_config = transformers.BitsAndBytesConfig(
+    load_in_4bit=True,  # 4-bit quantization
+    bnb_4bit_quant_type='nf4',  # Normalized float 4
+    bnb_4bit_use_double_quant=True,  # Second quantization after the first
+    bnb_4bit_compute_dtype=bfloat16  # Computation type
+)
+
+# Llama 2 Tokenizer
+tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
+
+# Llama 2 Model
+model = transformers.AutoModelForCausalLM.from_pretrained(
+    model_id,
+    trust_remote_code=True,
+    quantization_config=bnb_config,
+    device_map='auto',
+)
+model.eval()
+
+# Our text generator
+generator = transformers.pipeline(
+    model=model, tokenizer=tokenizer,
+    task='text-generation',
+    temperature=0.1,
+    max_new_tokens=500,
+    repetition_penalty=1.1
+)
+```
+
+After doing so, we will need to define a prompt that works with both Llama 2 as well as BERTopic:
+
+
+```python
+# System prompt describes information given to all conversations
+system_prompt = """
+<s>[INST] <<SYS>>
+You are a helpful, respectful and honest assistant for labeling topics.
+<</SYS>>
+"""
+
+# Example prompt demonstrating the output we are looking for
+example_prompt = """
+I have a topic that contains the following documents:
+- Traditional diets in most cultures were primarily plant-based with a little meat on top, but with the rise of industrial style meat production and factory farming, meat has become a staple food.
+- Meat, but especially beef, is the word food in terms of emissions.
+- Eating meat doesn't make you a bad person, not eating meat doesn't make you a good one.
+
+The topic is described by the following keywords: 'meat, beef, eat, eating, emissions, steak, food, health, processed, chicken'.
+
+Based on the information about the topic above, please create a short label of this topic. Make sure you to only return the label and nothing more.
+
+[/INST] Environmental impacts of eating meat
+"""
+
+# Our main prompt with documents ([DOCUMENTS]) and keywords ([KEYWORDS]) tags
+main_prompt = """
+[INST]
+I have a topic that contains the following documents:
+[DOCUMENTS]
+
+The topic is described by the following keywords: '[KEYWORDS]'.
+
+Based on the information about the topic above, please create a short label of this topic. Make sure you to only return the label and nothing more.
+[/INST]
+"""
+
+prompt = system_prompt + example_prompt + main_prompt
+```
+
+Three pieces of the prompt were created:  
+  
+* `system_prompt` helps us guide the model during a conversation. For example, we can say that it is a helpful assisant that is specialized in labeling topics.
+* `example_prompt` gives an example of a correctly labeled topic to guide Llama 2
+* `main_prompt` contains the main question we are going to ask it, namely to label a topic. Note that it uses the `[DOCUMENTS]`  and `[KEYWORDS]` to provide the most relevant documents and keywords as additional context
+
+After having generated our prompt template, we can start running our topic model:
+
+```python
+from bertopic.representation import TextGeneration
+from bertopic import BERTopic
+
+# Text generation with Llama 2
+llama2 = TextGeneration(generator, prompt=prompt)
+representation_model = {
+    "Llama2": llama2,
+}
+
+# Create our BERTopic model
+topic_model = BERTopic(representation_model=representation_model,  verbose=True)
+```
 
 
 ## **OpenAI**


### PR DESCRIPTION
Truncate documents to a specific length when using any LLM for fine-tuning topic representations (#1527). It introduces two parameters:

* `doc_length`
    * The maximum length of each document. If a document is longer, it will be truncated. If None, the entire document is passed.
* `tokenizer`
    * The tokenizer used to calculate to split the document into segments used to count the length of a document. 
        * If tokenizer is  `'char'`, then the document is split up into characters which are counted to adhere to `doc_length`
        * If tokenizer is `'whitespace'`, the the document is split up into words separated by whitespaces. These words are counted       and truncated depending on `doc_length`
        * If tokenizer is `'vectorizer'`, then the internal CountVectorizer is used to tokenize the document. These tokens are counted and trunctated depending on `doc_length`
        * If tokenizer is a callable, then that callable is used to tokenized the document. These tokens are counted and truncated depending on `doc_length`

This means that the definition of `doc_length` changes depending on what constitutes a token in the `tokenizer` parameter. If a token is a character, then `doc_length` refers to max length in characters. If a token is a word, then `doc_length` refers to the max length in words.

The example below essentially states that documents cannot be longer than 100 tokens. Anything more than that will be truncated. 

It uses tiktoken which can be installed as follows together with openai:

```bash
pip install tiktoken openai bertopic
```

Example:

```python
import openai
import tiktoken
from bertopic.representation import OpenAI
from bertopic import BERTopic

# Tokenizer
tokenizer= tiktoken.encoding_for_model("gpt-3.5-turbo")

# Create your representation model
openai.api_key = MY_API_KEY
representation_model = OpenAI(
    model="gpt-3.5-turbo", 
    delay_in_seconds=2, 
    chat=True,
    doc_length=100,
    tokenizer=tokenizer
)

# Use the representation model in BERTopic on top of the default pipeline
topic_model = BERTopic(representation_model=representation_model)
```