### PR TITLE
Support for LCEL Runnables

### DIFF
--- a/bertopic/representation/_langchain.py
+++ b/bertopic/representation/_langchain.py
@@ -123,7 +123,7 @@ class LangChain(BaseRepresentation):
 
         # `self.chain` must return a dict with a `text` key
         outputs: List[Dict[str, str]] = self.chain.batch(inputs=inputs, config=self.config)
-        labels: List[str] = [output["text"].strip() for output in outputs]
+        labels: List[str] = [output["output_text"].strip() for output in outputs]
 
         updated_topics = {
             topic: [(label, 1)] + [("", 0) for _ in range(9)]

--- a/bertopic/representation/_langchain.py
+++ b/bertopic/representation/_langchain.py
@@ -1,6 +1,5 @@
 import pandas as pd
 from langchain.docstore.document import Document
-from langchain.schema.runnable import Runnable, RunnableConfig
 from scipy.sparse import csr_matrix
 from typing import Callable, Dict, Mapping, List, Tuple, Union
 

--- a/bertopic/representation/_langchain.py
+++ b/bertopic/representation/_langchain.py
@@ -121,8 +121,9 @@ class LangChain(BaseRepresentation):
             for docs in chain_docs
         ]
 
-        # `self.chain` must return a dict with a `text` key
+        # `self.chain` must return a dict with an `output_text` key
         outputs: List[Dict[str, str]] = self.chain.batch(inputs=inputs, config=self.config)
+        # same output key as the `StuffDocumentsChain` returned by `load_qa_chain`
         labels: List[str] = [output["output_text"].strip() for output in outputs]
 
         updated_topics = {

--- a/bertopic/representation/_langchain.py
+++ b/bertopic/representation/_langchain.py
@@ -18,9 +18,9 @@ class LangChain(BaseRepresentation):
     You can also use Runnables such as those composed using the LangChain Expression Language.
 
     Arguments:
-        chain: A langchain chain or Runnable with a `batch` method.
-            Input keys must be `input_documents` and `question`.
-            Output key must be `output_text`.
+        chain: The langchain chain or Runnable with a `batch` method.
+               Input keys must be `input_documents` and `question`.
+               Output key must be `output_text`.
         prompt: The prompt to be used in the model. If no prompt is given,
                 `self.default_prompt_` is used instead.
         nr_docs: The number of documents to pass to LangChain if a prompt
@@ -45,9 +45,8 @@ class LangChain(BaseRepresentation):
                        * If tokenizer is a callable, then that callable is used to tokenize
                          the document. These tokens are counted and truncated depending
                          on `doc_length`
-        chain_config : RunnableConfig, optional
-            Configuration for the langchain chain. Can be used to set
-            options like max_concurrency to avoid rate limiting errors.
+        chain_config: The configuration for the langchain chain. Can be used to set options
+                      like max_concurrency to avoid rate limiting errors.
     Usage:
 
     To use this, you will need to install the langchain package first.

--- a/bertopic/representation/_langchain.py
+++ b/bertopic/representation/_langchain.py
@@ -81,11 +81,11 @@ class LangChain(BaseRepresentation):
     def __init__(self,
                  chain,
                  prompt: str = None,
-                 chain_config = None,
                  nr_docs: int = 4,
                  diversity: float = None,
                  doc_length: int = None,
-                 tokenizer: Union[str, Callable] = None
+                 tokenizer: Union[str, Callable] = None,
+                 chain_config = None,
                  ):
         self.chain = chain
         self.prompt = prompt if prompt is not None else DEFAULT_PROMPT

--- a/bertopic/representation/_langchain.py
+++ b/bertopic/representation/_langchain.py
@@ -59,11 +59,11 @@ class LangChain(BaseRepresentation):
     # TODO: update docstring
     def __init__(self,
                  chain: Runnable,
-                 prompt: str = None,
-                 config: Optional[Union[RunnableConfig, Dict[str, Any]]] = None,
+                 prompt: Optional[str] = None,
+                 config: Union[RunnableConfig, Dict[str, Any], None] = None,
                  nr_samples: int = 500,
                  nr_repr_docs: int = 4,
-                 diversity: float = None,
+                 diversity: Optional[float] = None,
                  truncate_len: Union[int, None] = 1000,
                  ):
         self.chain = chain
@@ -80,7 +80,7 @@ class LangChain(BaseRepresentation):
                        documents: pd.DataFrame,
                        c_tf_idf: csr_matrix,
                        topics: Mapping[str, List[Tuple[str, float]]]
-                       ) -> Mapping[str, List[Tuple[str, float]]]:
+                       ) -> Mapping[str, List[Tuple[str, int]]]:
         """ Extract topics
 
         Arguments:
@@ -116,7 +116,7 @@ class LangChain(BaseRepresentation):
         ]
 
         # `self.chain` must take `input_documents` and `question` as input keys
-        inputs: List[Dict[str, str]] = [
+        inputs: List[Dict[str, Union[List[str], str]]] = [
             {"input_documents": docs, "question": self.prompt}
             for docs in chain_docs
         ]

--- a/bertopic/representation/_langchain.py
+++ b/bertopic/representation/_langchain.py
@@ -2,8 +2,7 @@ import pandas as pd
 from langchain.docstore.document import Document
 from langchain.schema.runnable import Runnable, RunnableConfig
 from scipy.sparse import csr_matrix
-from tqdm import tqdm
-from typing import Any, Callable, Dict, Mapping, List, Optional, Tuple, Union
+from typing import Callable, Dict, Mapping, List, Tuple, Union
 
 from bertopic.representation._base import BaseRepresentation
 from bertopic.representation._utils import truncate_document
@@ -142,15 +141,15 @@ class LangChain(BaseRepresentation):
         ]
 
         # `self.chain` must take `input_documents` and `question` as input keys
-        inputs: List[Dict[str, Union[List[str], str]]] = [
+        inputs = [
             {"input_documents": docs, "question": self.prompt}
             for docs in chain_docs
         ]
 
         # `self.chain` must return a dict with an `output_text` key
-        outputs: List[Dict[str, str]] = self.chain.batch(inputs=inputs, config=self.chain_config)
         # same output key as the `StuffDocumentsChain` returned by `load_qa_chain`
-        labels: List[str] = [output["output_text"].strip() for output in outputs]
+        outputs = self.chain.batch(inputs=inputs, config=self.chain_config)
+        labels = [output["output_text"].strip() for output in outputs]
 
         updated_topics = {
             topic: [(label, 1)] + [("", 0) for _ in range(9)]


### PR DESCRIPTION
# Summary

This PR addresses https://github.com/MaartenGr/BERTopic/issues/1564 by enhancing the `LangChain` representation class to support more flexible LangChain pipelines, including LCEL Runnables. I am certainly open to more changes as needed before merging.

## Changes

- Generalize `chain` parameter to take any `Runnable` object instead of just QA chains
- Add `chain_config` parameter to support `RunnableConfig`
- Use `.batch()` instead of `.run()` to invoke chains
- Fix return type in `extract_topics`
- Update docstring for `LangChain.__init__`

## Example Usage

Here is an example of using a custom LCEL pipeline with the updated `LangChain` class (from the updated docstring):

```python
from bertopic.representation import LangChain
from langchain.chains.question_answering import load_qa_chain
from langchain.chat_models import ChatAnthropic
from langchain.schema.document import Document
from langchain.schema.runnable import RunnablePassthrough
from langchain_experimental.data_anonymizer.presidio import PresidioReversibleAnonymizer

prompt = ...
llm = ...

# We will construct a special privacy-preserving chain using Microsoft Presidio

pii_handler = PresidioReversibleAnonymizer(analyzed_fields=["PERSON"])

chain = (
        {
            "input_documents": (
                lambda inp: [
                    Document(
                        page_content=pii_handler.anonymize(
                            d.page_content,
                            language="en",
                        ),
                    )
                    for d in inp["input_documents"]
                ]
            ),
            "question": RunnablePassthrough(),
        }
        | load_qa_chain(representation_llm, chain_type="stuff")
        | (lambda output: {"output_text": pii_handler.deanonymize(output["output_text"])})
)

representation_model = LangChain(chain, prompt=representation_prompt)
```