### PR TITLE
Fix TopicMapper example usage docstring

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -4030,7 +4030,7 @@ class TopicMapper:
 
         To get mappings, simply call:
         ```python
-        mapper = TopicMapper(hdbscan_model)
+        mapper = TopicMapper(topics)
         mappings = mapper.get_mappings(original_topics=False)
         ```
         """


### PR DESCRIPTION
A `hdbscan_model` can't be used to construct a `TopicMapper`, so I've updated it to a nondescript `topics` variable to at least mitigate confusion. 

Perhaps the original intention was to provide `hdbscan_model.labels_` as the example, which may be a more informative example.