### PR TITLE
Update _bertopic.py to fix question/ github issue #1696

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -456,7 +456,10 @@ class BERTopic:
         """ After having fit a model, use transform to predict new instances
 
         Arguments:
-            documents: A single document or a list of documents to predict on
+            documents: A single document or a list of documents to predict on.                    
+                       Note that the behavior of the method might differ depending 
+                       on whether a single document or a list of documents is passed
+                       (especially when using the HDBSCAN algorithm)
             embeddings: Pre-trained document embeddings. These can be used
                         instead of the sentence-transformer model.
             images: A list of paths to the images to predict on or the images themselves

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -456,10 +456,10 @@ class BERTopic:
         """ After having fit a model, use transform to predict new instances
 
         Arguments:
-            documents: A single document or a list of documents to predict on.                    
-                       Note that the behavior of the method might differ depending 
-                       on whether a single document or a list of documents is passed,
-                       particularly when using HDBSCAN, where this distinction is algorithm-specific.
+            documents: A single document or a list of documents for which to predict topic(s).
+                       NOTE: When using HDBSCAN, predictions may differ depending on whether
+                       a single document or a list of documents is provided, as HDBSCAN
+                       leverages the presence of other data points during prediction.
             embeddings: Pre-trained document embeddings. These can be used
                         instead of the sentence-transformer model.
             images: A list of paths to the images to predict on or the images themselves

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -458,8 +458,8 @@ class BERTopic:
         Arguments:
             documents: A single document or a list of documents to predict on.                    
                        Note that the behavior of the method might differ depending 
-                       on whether a single document or a list of documents is passed
-                       (especially when using the HDBSCAN algorithm)
+                       on whether a single document or a list of documents is passed,
+                       particularly when using HDBSCAN, where this distinction is algorithm-specific.
             embeddings: Pre-trained document embeddings. These can be used
                         instead of the sentence-transformer model.
             images: A list of paths to the images to predict on or the images themselves


### PR DESCRIPTION
As discussed in https://github.com/MaartenGr/BERTopic/issues/1696, I provide an updated doc string to reflect that `topic_model.transform(docs)[0][i]` is sometimes different from `topic_model.transform(docs[i])[0][0]`