### PR TITLE
Fix bug in TextGeneration prompt creation when prompt template does not contain [DOCUMENTS]

### DIFF
--- a/bertopic/representation/_textgeneration.py
+++ b/bertopic/representation/_textgeneration.py
@@ -144,7 +144,7 @@ class TextGeneration(BaseRepresentation):
         for topic, docs in tqdm(repr_docs_mappings.items(), disable=not topic_model.verbose):
 
             # Prepare prompt
-            truncated_docs = [truncate_document(topic_model, self.doc_length, self.tokenizer, doc) for doc in docs]
+            truncated_docs = [truncate_document(topic_model, self.doc_length, self.tokenizer, doc) for doc in docs] if docs is not None else docs
             prompt = self._create_prompt(truncated_docs, topic, topics)
             self.prompts_.append(prompt)
 


### PR DESCRIPTION
Prevent attempted iteration over NoneType when prompt template does not contain [DOCUMENTS] in TextGeneration class.

When DEFAULT_PROMPT is used or the user-provided prompt does not contain "[DOCUMENTS]", all of the values in repr_docs_mappings are None. When defining truncated_docs, iteration is attempted over NoneType. This change prevents the attempted iteration and instead passes the None value to _create_prompt.