### PR TITLE
Fixed warning when saving a topic model without an embedding model 

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -2996,7 +2996,7 @@ class BERTopic:
                 logger.warning("You are saving a BERTopic model without explicitly defining an embedding model."
                                "If you are using a sentence-transformers model or a HuggingFace model supported"
                                "by sentence-transformers, please save the model by using a pointer towards that model."
-                               "For example, `save_embedding_model='sentence-transformers/all-mpnet-base-v2'`", RuntimeWarning)
+                               "For example, `save_embedding_model='sentence-transformers/all-mpnet-base-v2'`")
 
             # Minimal
             save_utils.save_hf(model=self, save_directory=save_directory, serialization=serialization)


### PR DESCRIPTION
Addresses #1694

Fixed `logger.warning()` formatting by removing `RuntimeWarning` argument. I'm not sure if you had some intention by including that...? 

This now matches the format of other warnings throughout the module and doesn't raise an error. 