### PR TITLE
Update deprecated OpenAI embedding model

### DIFF
--- a/bertopic/representation/_openai.py
+++ b/bertopic/representation/_openai.py
@@ -137,7 +137,7 @@ class OpenAI(BaseRepresentation):
     """
     def __init__(self,
                  client,
-                 model: str = "text-ada-001",
+                 model: str = "text-embedding-3-small",
                  prompt: str = None,
                  generator_kwargs: Mapping[str, Any] = {},
                  delay_in_seconds: float = None,


### PR DESCRIPTION
Replacing the deprecated text-ada-001 model with the latest text-embedding-3-small from OpenAI