### PR TITLE
Fix type hint in ClassTfidfTransformer constructor

### DIFF
--- a/bertopic/vectorizers/_ctfidf.py
+++ b/bertopic/vectorizers/_ctfidf.py
@@ -43,7 +43,7 @@ class ClassTfidfTransformer(TfidfTransformer):
                  bm25_weighting: bool = False, 
                  reduce_frequent_words: bool = False,
                  seed_words: List[str] = None,
-                 seed_multiplier: bool = 2
+                 seed_multiplier: float = 2
                  ):
         self.bm25_weighting = bm25_weighting
         self.reduce_frequent_words = reduce_frequent_words


### PR DESCRIPTION
I see only examples of integers being used for `seed_multiplier` in the documentation and for the default, but see no reason why a floating point number could not be used. In any case, `bool` is inconsistent and presumably a typographic error. 

(Please excuse the lack of creating an issue in advance of this very minor fix.)