### PR TITLE
remove commas from pip install reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you want to install BERTopic with other embedding models, you can choose one 
 
 ```bash
 # Choose an embedding backend
-pip install bertopic[flair, gensim, spacy, use]
+pip install bertopic[flair,gensim,spacy,use]
 
 # Topic modeling with images
 pip install bertopic[vision]


### PR DESCRIPTION
with the commas it will throw an error when installing