### PR TITLE
add automatic height scaling and font resize

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -2960,7 +2960,8 @@ class BERTopic:
                            custom_labels: bool = False,
                            title: str = "Topic Word Scores",
                            width: int = 250,
-                           height: int = 250) -> go.Figure:
+                           height: int = 250,
+                           autoscale: bool=False) -> go.Figure:
         """ Visualize a barchart of selected topics
 
         Arguments:
@@ -2972,6 +2973,7 @@ class BERTopic:
             title: Title of the plot.
             width: The width of each figure.
             height: The height of each figure.
+            autoscale: Whether to automatically calculate the height of the figures to fit the whole bar text
 
         Returns:
             fig: A plotly figure
@@ -3000,7 +3002,8 @@ class BERTopic:
                                            custom_labels=custom_labels,
                                            title=title,
                                            width=width,
-                                           height=height)
+                                           height=height,
+                                           autoscale=autoscale)
 
     def save(self,
              path,

--- a/bertopic/plotting/_barchart.py
+++ b/bertopic/plotting/_barchart.py
@@ -13,7 +13,8 @@ def visualize_barchart(topic_model,
                        custom_labels: Union[bool, str] = False,
                        title: str = "<b>Topic Word Scores</b>",
                        width: int = 250,
-                       height: int = 250) -> go.Figure:
+                       height: int = 250,
+                       autoscale: bool=False) -> go.Figure:
     """ Visualize a barchart of selected topics
 
     Arguments:
@@ -27,6 +28,7 @@ def visualize_barchart(topic_model,
         title: Title of the plot.
         width: The width of each figure.
         height: The height of each figure.
+        autoscale: Whether to automatically calculate the height of the figures to fit the whole bar text
 
     Returns:
         fig: A plotly figure
@@ -93,13 +95,14 @@ def visualize_barchart(topic_model,
                    marker_color=next(colors)),
             row=row, col=column)
 
-        if len(words) > 12:
-            height = 250 + (len(words) - 12) * 11
+        if autoscale:
+            if len(words) > 12:
+                height = 250 + (len(words) - 12) * 11
 
-        if len(words) > 9:
-            fig.update_yaxes(
-                tickfont=dict(size=(height - 140) // len(words))
-            )
+            if len(words) > 9:
+                fig.update_yaxes(
+                    tickfont=dict(size=(height - 140) // len(words))
+                )
 
         if column == columns:
             column = 1

--- a/bertopic/plotting/_barchart.py
+++ b/bertopic/plotting/_barchart.py
@@ -93,6 +93,14 @@ def visualize_barchart(topic_model,
                    marker_color=next(colors)),
             row=row, col=column)
 
+        if len(words) > 12:
+            height = 250 + (len(words) - 12) * 11
+
+        if len(words) > 9:
+            fig.update_yaxes(
+                tickfont=dict(size=(height - 140) // len(words))
+            )
+
         if column == columns:
             column = 1
             row += 1


### PR DESCRIPTION
This PR tackles issue https://github.com/MaartenGr/BERTopic/issues/1858. The issue is solved by scaling the font size up to 12 words. Starting from 12 words the words become slightly harder to read, so a slight height update for the figure is done.

Example for 10, 15, and 30 words:

![topics_barchart_10](https://github.com/MaartenGr/BERTopic/assets/94498051/4205b40f-ebd4-49a2-9238-0a9bdf9d1fa1)
![topics_barchart_15](https://github.com/MaartenGr/BERTopic/assets/94498051/d941588c-67d7-4c4a-891e-3727ffecfef2)
![topics_barchart_30](https://github.com/MaartenGr/BERTopic/assets/94498051/67c89903-eb0d-400a-804a-3232b6efe815)

