### PR TITLE
Update multimodal.md to add axis keyword [Issue #1884]

### DIFF
--- a/docs/getting_started/multimodal/multimodal.md
+++ b/docs/getting_started/multimodal/multimodal.md
@@ -64,7 +64,7 @@ def image_formatter(im):
     return f'<img src="data:image/jpeg;base64,{image_base64(im)}">'
 
 # Extract dataframe
-df = topic_model.get_topic_info().drop("Representative_Docs", 1).drop("Name", 1)
+df = topic_model.get_topic_info().drop(["Representative_Docs","Name"], axis=1)
 
 # Visualize the images
 HTML(df.to_html(formatters={'Visual_Aspect': image_formatter}, escape=False))
@@ -179,7 +179,7 @@ def image_formatter(im):
     return f'<img src="data:image/jpeg;base64,{image_base64(im)}">'
 
 # Extract dataframe
-df = topic_model.get_topic_info().drop("Representative_Docs", 1).drop("Name", 1)
+df = topic_model.get_topic_info().drop(["Representative_Docs","Name"], axis=1)
 
 # Visualize the images
 HTML(df.to_html(formatters={'Visual_Aspect': image_formatter}, escape=False))


### PR DESCRIPTION
Update Multimodal documentation to add an axis keyword for the drop function. This addresses issue #1884

Existing Code: 
```
# Extract dataframe
df = topic_model.get_topic_info().drop("Representative_Docs", 1).drop("Name", 1)
```

Suggested Code:
`# Extract dataframe
df = topic_model.get_topic_info().drop(["Representative_Docs","Name"], axis=1)`

This corrects the following error caused by the need for keyword arguments in newer versions of pandas. Columns to drop were gathered into a single list just for simplicity.
`---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[12], line 1
----> 1 df.drop("Representative_Docs", 1).drop("Name", 1)

TypeError: DataFrame.drop() takes from 1 to 2 positional arguments but 3 were given`