### PR TITLE
Fix issue with `.merge_models` seemingly skipping topic

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3237,7 +3237,7 @@ class BERTopic:
 
             # Extract new topics
             new_topics = sorted([index - selected_topics["_outliers"] for index, sim in enumerate(sims) if sim < min_similarity])
-            max_topic = max(set(merged_topics["topics"])) + 1
+            max_topic = max(set(merged_topics["topics"]))
 
             # Merge Topic Representations
             new_topics_dict = {}

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3237,41 +3237,41 @@ class BERTopic:
 
             # Extract new topics
             new_topics = sorted([index - selected_topics["_outliers"] for index, sim in enumerate(sims) if sim < min_similarity])
-            max_topic = max(set(merged_topics["topics"]))
+            max_topic = max(set(merged_topics["topics"])) + 1
 
             # Merge Topic Representations
             new_topics_dict = {}
-            new_topic_val = max_topic + 1
-            for index, new_topic in enumerate(new_topics):
-                new_topic_val = max_topic + index + 1
-                new_topics_dict[new_topic] = new_topic_val
-                merged_topics["topic_representations"][str(new_topic_val)] = selected_topics["topic_representations"][str(new_topic)]
-                merged_topics["topic_labels"][str(new_topic_val)] = selected_topics["topic_labels"][str(new_topic)]
+            for new_topic in new_topics:
+                if new_topic != -1:
+                    max_topic += 1
+                    new_topics_dict[new_topic] = max_topic
+                    merged_topics["topic_representations"][str(max_topic)] = selected_topics["topic_representations"][str(new_topic)]
+                    merged_topics["topic_labels"][str(max_topic)] = selected_topics["topic_labels"][str(new_topic)]
 
-                # Add new aspects
-                if selected_topics["topic_aspects"]:
-                    aspects_1 = set(merged_topics["topic_aspects"].keys())
-                    aspects_2 = set(selected_topics["topic_aspects"].keys())
-                    aspects_diff = aspects_2.difference(aspects_1)
-                    if aspects_diff:
-                        for aspect in aspects_diff:
-                            merged_topics["topic_aspects"][aspect] = {}
+                    # Add new aspects
+                    if selected_topics["topic_aspects"]:
+                        aspects_1 = set(merged_topics["topic_aspects"].keys())
+                        aspects_2 = set(selected_topics["topic_aspects"].keys())
+                        aspects_diff = aspects_2.difference(aspects_1)
+                        if aspects_diff:
+                            for aspect in aspects_diff:
+                                merged_topics["topic_aspects"][aspect] = {}
 
-                    # If the original model does not have topic aspects but the to be added model does
-                    if not merged_topics.get("topic_aspects"):
-                        merged_topics["topic_aspects"] = selected_topics["topic_aspects"]
+                        # If the original model does not have topic aspects but the to be added model does
+                        if not merged_topics.get("topic_aspects"):
+                            merged_topics["topic_aspects"] = selected_topics["topic_aspects"]
 
-                    # If they both contain topic aspects, add to the existing set of aspects
-                    else:
-                        for aspect, values in selected_topics["topic_aspects"].items():
-                            merged_topics["topic_aspects"][aspect][str(new_topic_val)] = values[str(new_topic)]
+                        # If they both contain topic aspects, add to the existing set of aspects
+                        else:
+                            for aspect, values in selected_topics["topic_aspects"].items():
+                                merged_topics["topic_aspects"][aspect][str(max_topic)] = values[str(new_topic)]
 
-                # Add new embeddings
-                new_tensors = tensors[new_topic + selected_topics["_outliers"]]
-                merged_tensors = np.vstack([merged_tensors, new_tensors])
+                    # Add new embeddings
+                    new_tensors = tensors[new_topic + selected_topics["_outliers"]]
+                    merged_tensors = np.vstack([merged_tensors, new_tensors])
 
             # Topic Mapper
-            merged_topics["topic_mapper"] = TopicMapper(list(range(-1, new_topic_val+1, 1))).mappings_
+            merged_topics["topic_mapper"] = TopicMapper(list(range(-1, max_topic+1, 1))).mappings_
 
             # Find similar topics and re-assign those from the new models
             sims_idx = np.argmax(sim_matrix, axis=1)


### PR DESCRIPTION
Adresses #1866

In some cases, when using `.merge_models`, it seemed that the added topics to a base model were assigned with an incorrect numbering. For instance, if the maximum topic of the base model was 5, the newly added topics would start at 7. 

This issue fixes that problem and additionally ignores outlier classes as it seems there is no benefit to combining them. 

Lastly, this should also fix the topic embeddings being in the incorrect order. 