### PR TITLE
Fix Cohere client.embed TypeError

### DIFF
--- a/bertopic/backend/_cohere.py
+++ b/bertopic/backend/_cohere.py
@@ -76,7 +76,7 @@ class CohereBackend(BaseEmbedder):
         if self.batch_size is not None:
             embeddings = []
             for batch in tqdm(self._chunks(documents), disable=not verbose):
-                response = self.client.embed(batch, **self.embed_kwargs)
+                response = self.client.embed(texts=batch, **self.embed_kwargs)
                 embeddings.extend(response.embeddings)
 
                 # Delay subsequent calls
@@ -85,7 +85,7 @@ class CohereBackend(BaseEmbedder):
 
         # Extract embeddings all at once
         else:
-            response = self.client.embed(documents, **self.embed_kwargs)
+            response = self.client.embed(texts=documents, **self.embed_kwargs)
             embeddings = response.embeddings
         return np.array(embeddings)
 


### PR DESCRIPTION
The following code:

```python
import cohere
from bertopic import BERTopic
from bertopic.backend import CohereBackend

# Create the Cohere model with specific embedding settings
client = cohere.Client("MY_KEY")
cohere_model = CohereBackend(
    client,
    embedding_model="embed-english-v3.0",
    embed_kwargs={"input_type": "clustering"}
)

# Initialize BERTopic with the CohereBackend model
topic_model = BERTopic(embedding_model=cohere_model)

# Fit the BERTopic model 
topics, probabilities = topic_model.fit_transform(["test one", "test two"])
```

Gives me the following error on BERTopic v0.16 and cohere v5.1.7:

```bash
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
[<ipython-input-3-be5151b26d2a>](https://localhost:8080/#) in <cell line: 17>()
     15 
     16 # Fit the BERTopic model using 'tweet_list'
---> 17 topics, probabilities = topic_model.fit_transform(["test one", "test two"])

3 frames
[/usr/local/lib/python3.10/dist-packages/bertopic/_bertopic.py](https://localhost:8080/#) in fit_transform(self, documents, embeddings, images, y)
    385             self.embedding_model = select_backend(self.embedding_model,
    386                                                   language=self.language)
--> 387             embeddings = self._extract_embeddings(documents.Document.values.tolist(),
    388                                                   images=images,
    389                                                   method="document",

[/usr/local/lib/python3.10/dist-packages/bertopic/_bertopic.py](https://localhost:8080/#) in _extract_embeddings(self, documents, images, method, verbose)
   3408             embeddings = self.embedding_model.embed_words(words=documents, verbose=verbose)
   3409         elif method == "document":
-> 3410             embeddings = self.embedding_model.embed_documents(documents, verbose=verbose)
   3411         elif documents[0] is None and images is None:
   3412             raise ValueError("Make sure to use an embedding model that can either embed documents"

[/usr/local/lib/python3.10/dist-packages/bertopic/backend/_base.py](https://localhost:8080/#) in embed_documents(self, document, verbose)
     67             that each have an embeddings size of `m`
     68         """
---> 69         return self.embed(document, verbose)

[/usr/local/lib/python3.10/dist-packages/bertopic/backend/_cohere.py](https://localhost:8080/#) in embed(self, documents, verbose)
     86         # Extract embeddings all at once
     87         else:
---> 88             response = self.client.embed(documents, **self.embed_kwargs)
     89             embeddings = response.embeddings
     90         return np.array(embeddings)

TypeError: Client.embed() takes 1 positional argument but 2 positional arguments (and 2 keyword-only arguments) were given
```

I believe the solution should be straightforward based on the updated version of the cohere package by simply adding the `texts` parameter specifically to prevent issues with keyword assignments. 