### PR TITLE
ci: bump github actions versions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: [3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Hi @MaartenGr,

this is my first PR to the project. I have read the contributor guide. I did not create an issue first, because the changes proposed are trivial. What do you think?

This PR bumps the versions of the used GitHub Actions, which will get rid of the warnings (e.g. `Node.js 16 actions are deprecated. [...]` in the [Annotations section under Actions](https://github.com/MaartenGr/BERTopic/actions/runs/8773439413).