### PR TITLE
feat: add support for python 3.10+

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,9 @@ setup(
         "Operating System :: MacOS",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     install_requires=base_packages,
     extras_require={


### PR DESCRIPTION
See #1950

This will run the test suite five times for Python 3.8-3.12. You could also opt for only running 3.8 and 3.12. Running it five times is safer I guess, so you will know if things go wrong in 3.10 and 3.11 as well.