### PR TITLE
Make sklearn embedding backend auto-select more cautious

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -383,7 +383,8 @@ class BERTopic:
         if embeddings is None:
             logger.info("Embedding - Transforming documents to embeddings.")
             self.embedding_model = select_backend(self.embedding_model,
-                                                  language=self.language)
+                                                  language=self.language,
+                                                  verbose=self.verbose)
             embeddings = self._extract_embeddings(documents.Document.values.tolist(),
                                                   images=images,
                                                   method="document",
@@ -630,14 +631,16 @@ class BERTopic:
         if embeddings is None:
             if self.topic_representations_ is None:
                 self.embedding_model = select_backend(self.embedding_model,
-                                                      language=self.language)
+                                                      language=self.language,
+                                                      verbose=self.verbose)
             embeddings = self._extract_embeddings(documents.Document.values.tolist(),
                                                   method="document",
                                                   verbose=self.verbose)
         else:
             if self.embedding_model is not None and self.topic_representations_ is None:
                 self.embedding_model = select_backend(self.embedding_model,
-                                                      language=self.language)
+                                                      language=self.language,
+                                                      verbose=self.verbose)
 
         # Reduce dimensionality
         if self.seed_topic_list is not None and self.embedding_model is not None:
@@ -3143,7 +3146,7 @@ class BERTopic:
             with open(file_or_dir, 'rb') as file:
                 if embedding_model:
                     topic_model = joblib.load(file)
-                    topic_model.embedding_model = select_backend(embedding_model)
+                    topic_model.embedding_model = select_backend(embedding_model, verbose=self.verbose)
                 else:
                     topic_model = joblib.load(file)
                 return topic_model
@@ -3294,7 +3297,7 @@ class BERTopic:
 
         # Replace embedding model if one is specifically chosen
         if embedding_model is not None and type(merged_model.embedding_model) == BaseEmbedder:
-            merged_model.embedding_model = select_backend(embedding_model)
+            merged_model.embedding_model = select_backend(embedding_model, verbose=self.verbose)
         return merged_model
 
     def push_to_hf_hub(

--- a/bertopic/backend/_utils.py
+++ b/bertopic/backend/_utils.py
@@ -7,6 +7,9 @@ from sklearn.decomposition import TruncatedSVD
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.pipeline import Pipeline as ScikitPipeline
 
+from bertopic._utils import MyLogger
+
+logger = MyLogger("WARNING")
 
 languages = [
     "arabic",
@@ -66,14 +69,20 @@ languages = [
 
 
 def select_backend(embedding_model,
-                   language: str = None) -> BaseEmbedder:
-    """ Select an embedding model based on language or a specific sentence transformer models.
+                   language: str = None,
+                   verbose: bool = False) -> BaseEmbedder:
+    """ Select an embedding model based on language or a specific provided model.
     When selecting a language, we choose all-MiniLM-L6-v2 for English and
     paraphrase-multilingual-MiniLM-L12-v2 for all other languages as it support 100+ languages.
+    If sentence-transformers is not installed, in the case of a lightweight installation,
+    a scikit-learn backend is default.
 
     Returns:
-        model: Either a Sentence-Transformer or Flair model
+        model: The selected model backend.
     """
+
+    logger.set_level("INFO" if verbose else "WARNING")
+
     # BERTopic language backend
     if isinstance(embedding_model, BaseEmbedder):
         return embedding_model
@@ -126,8 +135,14 @@ def select_backend(embedding_model,
                                 "Else, please select a language from the following list:\n"
                                 f"{languages}")
 
-        # Only for light-weight installation
-        except ModuleNotFoundError:
+        # A ModuleNotFoundError might be a lightweight installation
+        except ModuleNotFoundError as e:
+            if e.name != "sentence_transformers":
+                # Error occurred in a downstream module, probably not a lightweight install
+                raise e
+            # Whole sentence_transformers module is missing, probably a lightweight install
+            if verbose:
+                logger.info("Automatically selecting lightweight scikit-learn embedding backend as sentence-transformers appears to not be installed.")
             pipe = make_pipeline(TfidfVectorizer(), TruncatedSVD(100))
             return SklearnEmbedder(pipe)
 

--- a/bertopic/backend/_utils.py
+++ b/bertopic/backend/_utils.py
@@ -2,12 +2,11 @@ from ._base import BaseEmbedder
 
 # Imports for light-weight variant of BERTopic
 from bertopic.backend._sklearn import SklearnEmbedder
+from bertopic._utils import MyLogger
 from sklearn.pipeline import make_pipeline
 from sklearn.decomposition import TruncatedSVD
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.pipeline import Pipeline as ScikitPipeline
-
-from bertopic._utils import MyLogger
 
 logger = MyLogger("WARNING")
 


### PR DESCRIPTION
Fixes #1980 

- Checks which module the error ocurred in before selecting an sklearn backend by default. If it was `sentence_transformers`, select skelarn as it's probably a minimal install. If any other module, re-raise as this is abnormal.
- Logs an INFO message when the sklearn backend is selected, if verbose is enabled
- Updates the comments on `select_backend` as I think they were quite out of date

I ended up instantiating a new logger for this as it felt better to pass `verbose` than the whole logger.