### PR TITLE
Fix pipeline

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,7 @@ def supervised_topic_model(documents, document_embeddings, embedding_model, targ
 
 @pytest.fixture(scope="session")
 def online_topic_model(documents, document_embeddings, embedding_model):
-    umap_model = IncrementalPCA(n_components=5)
+    umap_model = PCA(n_components=5)
     cluster_model = MiniBatchKMeans(n_clusters=50, random_state=0)
     vectorizer_model = OnlineCountVectorizer(stop_words="english", decay=.01)
     model = BERTopic(umap_model=umap_model, hdbscan_model=cluster_model, vectorizer_model=vectorizer_model, embedding_model=embedding_model)


### PR DESCRIPTION
It seems there is a problem with scikit-learn v1.5 that breaks down the GitHub Actions Workflow. See #2005. However, from personal testing it seems that the issue does not lie with the functionality of scikit-learn but how `IncrementalPCA` is read from pytest. Not entirely sure why this is an issue but replacing it with PCA seems to work for now. 