### PR TITLE
ci: add cancel-in-progress to ci workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,6 +10,10 @@ on:
     - master
     - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When I added multiple commits to #1978 in quick succession, the current CI setup runs the tests for each commit individually, which leads to waiting time.

Desirable would be to cancel previous commits early and run the most recent one instead.

This is what concurrency.cancel-in-progress does.

Refs: 

- https://docs.github.com/en/actions/using-jobs/using-concurrency