### PR TITLE
Fix calls to self.verbose in class methods

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3146,7 +3146,7 @@ class BERTopic:
             with open(file_or_dir, 'rb') as file:
                 if embedding_model:
                     topic_model = joblib.load(file)
-                    topic_model.embedding_model = select_backend(embedding_model, topic_model.verbose)
+                    topic_model.embedding_model = select_backend(embedding_model, verbose=topic_model.verbose)
                 else:
                     topic_model = joblib.load(file)
                 return topic_model
@@ -3163,7 +3163,7 @@ class BERTopic:
 
         # Replace embedding model if one is specifically chosen
         if embedding_model is not None:
-            topic_model.embedding_model = select_backend(embedding_model, topic_model.verbose)
+            topic_model.embedding_model = select_backend(embedding_model, verbose=topic_model.verbose)
 
         return topic_model
 

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3146,7 +3146,7 @@ class BERTopic:
             with open(file_or_dir, 'rb') as file:
                 if embedding_model:
                     topic_model = joblib.load(file)
-                    topic_model.embedding_model = select_backend(embedding_model, verbose=self.verbose)
+                    topic_model.embedding_model = select_backend(embedding_model, topic_model.verbose)
                 else:
                     topic_model = joblib.load(file)
                 return topic_model
@@ -3163,7 +3163,7 @@ class BERTopic:
 
         # Replace embedding model if one is specifically chosen
         if embedding_model is not None:
-            topic_model.embedding_model = select_backend(embedding_model)
+            topic_model.embedding_model = select_backend(embedding_model, topic_model.verbose)
 
         return topic_model
 
@@ -3296,8 +3296,9 @@ class BERTopic:
         merged_model.embedding_model = models[0].embedding_model
 
         # Replace embedding model if one is specifically chosen
+        verbose = any([model.verbose for model in models])
         if embedding_model is not None and type(merged_model.embedding_model) == BaseEmbedder:
-            merged_model.embedding_model = select_backend(embedding_model, verbose=self.verbose)
+            merged_model.embedding_model = select_backend(embedding_model, verbose=verbose)
         return merged_model
 
     def push_to_hf_hub(


### PR DESCRIPTION
In #1984 a few usages of `self.verbose` in class methods slipped by.

I've changed these to check whether the model (or any model in the case of `merge_models`) is set to be verbose. I did consider just always running them as non-verbose, but I thought that really if you're loading an existing model, BERTopic deciding to use a different model by itself is even worse than usual.

Of course this also indicates these code paths don't have test coverage as this would've failed otherwise. Not sure if that should also be addressed.