### PR TITLE
Fixes to chain strategy example in outlier_reduction.md

### DIFF
--- a/docs/getting_started/outlier_reduction/outlier_reduction.md
+++ b/docs/getting_started/outlier_reduction/outlier_reduction.md
@@ -112,10 +112,10 @@ outliers that are left since this method is typically much slower:
 
 ```python
 # Use the "c-TF-IDF" strategy with a threshold
-new_topics = topic_model.reduce_outliers(docs, new_topics , strategy="c-tf-idf", threshold=0.1)
+new_topics = topic_model.reduce_outliers(docs, topics , strategy="c-tf-idf", threshold=0.1)
 
 # Reduce all outliers that are left with the "distributions" strategy
-new_topics = topic_model.reduce_outliers(docs, topics, strategy="distributions")
+new_topics = topic_model.reduce_outliers(docs, new_topics, strategy="distributions")
 ```
 
 


### PR DESCRIPTION
# What does this PR do?

The chain strategies example in the outlier reduction has `new_topics` being acted on in the first step and then `topics` acted on in the second step. I'm pretty sure this is supposed to be other way around. This fixes that. 


## Before submitting
- [ X] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [ ] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
