### PR TITLE
Add git blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Initial Ruff Linting
+70d7725e5c89bccfe7d4e5a3ccd87e05c642d74b


### PR DESCRIPTION
Adds git blame ignore to prevent most code in the repo being attributed to #2033.

GitHub will pick up on this by default.

Using Git locally, you can use this by passing the `--ignore-revs-file` argument e.g.
```sh
$ git blame bertopic/_bertopic.py --ignore-revs-file .git-blame-ignore-revs
```
or run this config to use by default
```sh
$ git config blame.ignoreRevsFile .git-blame-ignore-revs
```