### PR TITLE
ci: speed up by using uv to install python packages

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip 
-        pip install -e ".[test]"
+        python -m pip install uv
+        uv pip install --system --editable ".[test]"
     - name: Run Checking Mechanisms
       run: make check


### PR DESCRIPTION
# What does this PR do?

This is a proposal to use the [uv](https://github.com/astral-sh/uv/) for installing python packages in CI. It concurrently downloads the packages from pypi and improves the time of the install step significantly. From 3+ minutes to 30+ seconds.

What do you think?

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
