### PR TITLE
Fix #2102

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -313,7 +313,7 @@ class BERTopic:
         if self._is_zeroshot():
             # Need to correct labels from zero-shot topics
             topic_id_to_zeroshot_label = {
-                self.topic_mapper_.get_mappings()[topic_id]: self.zeroshot_topic_list[zeroshot_topic_idx]
+                topic_id: self.zeroshot_topic_list[zeroshot_topic_idx]
                 for topic_id, zeroshot_topic_idx in self._topic_id_to_zeroshot_topic_idx.items()
             }
             topic_labels.update(topic_id_to_zeroshot_label)

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -2143,7 +2143,7 @@ class BERTopic:
 
         # Update topics
         documents.Topic = documents.Topic.map(mapping)
-        self.topic_mapper_.add_mappings(mapping)
+        self.topic_mapper_.add_mappings(mapping, topic_model=self)
         documents = self._sort_mappings_by_frequency(documents)
         self._extract_topics(documents, mappings=mappings)
         self._update_topic_size(documents)
@@ -4402,49 +4402,11 @@ class BERTopic:
         # Map topics
         documents.Topic = new_topics
         self._update_topic_size(documents)
-        self.topic_mapper_.add_mappings(mapped_topics)
+        self.topic_mapper_.add_mappings(mapped_topics, topic_model=self)
 
         # Update representations
         documents = self._sort_mappings_by_frequency(documents)
         self._extract_topics(documents, mappings=mappings)
-
-        # When zero-shot topic(s) are present in the topics to merge,
-        # determine whether to take one of the zero-shot topic labels
-        # or use a calculated representation.
-        if self._is_zeroshot():
-            new_topic_id_to_zeroshot_topic_idx = {}
-            topics_to_map = {
-                topic_mapping[0]: topic_mapping[1] for topic_mapping in np.array(self.topic_mapper_.mappings_)[:, -2:]
-            }
-
-            for topic_to, topics_from in basic_mappings.items():
-                # When extracting topics, the reduced topics were reordered.
-                # Must get the updated topic_to.
-                topic_to = topics_to_map[topic_to]
-
-                # which of the original topics are zero-shot
-                zeroshot_topic_ids = [
-                    topic_id for topic_id in topics_from if topic_id in self._topic_id_to_zeroshot_topic_idx
-                ]
-                if len(zeroshot_topic_ids) == 0:
-                    continue
-
-                # If any of the original topics are zero-shot, take the best fitting zero-shot label
-                # if the cosine similarity with the new topic exceeds the zero-shot threshold
-                zeroshot_labels = [
-                    self.zeroshot_topic_list[self._topic_id_to_zeroshot_topic_idx[topic_id]]
-                    for topic_id in zeroshot_topic_ids
-                ]
-                zeroshot_embeddings = self._extract_embeddings(zeroshot_labels)
-                cosine_similarities = cosine_similarity(
-                    zeroshot_embeddings, [self.topic_embeddings_[topic_to]]
-                ).flatten()
-                best_zeroshot_topic_idx = np.argmax(cosine_similarities)
-                best_cosine_similarity = cosine_similarities[best_zeroshot_topic_idx]
-                if best_cosine_similarity >= self.zeroshot_min_similarity:
-                    new_topic_id_to_zeroshot_topic_idx[topic_to] = zeroshot_topic_ids[best_zeroshot_topic_idx]
-
-            self._topic_id_to_zeroshot_topic_idx = new_topic_id_to_zeroshot_topic_idx
 
         self._update_topic_size(documents)
         return documents
@@ -4498,7 +4460,7 @@ class BERTopic:
         }
 
         # Update documents and topics
-        self.topic_mapper_.add_mappings(mapped_topics)
+        self.topic_mapper_.add_mappings(mapped_topics, topic_model=self)
         documents = self._sort_mappings_by_frequency(documents)
         self._extract_topics(documents, mappings=mappings)
         self._update_topic_size(documents)
@@ -4538,7 +4500,7 @@ class BERTopic:
         df = pd.DataFrame(self.topic_sizes_.items(), columns=["Old_Topic", "Size"]).sort_values("Size", ascending=False)
         df = df[df.Old_Topic != -1]
         sorted_topics = {**{-1: -1}, **dict(zip(df.Old_Topic, range(len(df))))}
-        self.topic_mapper_.add_mappings(sorted_topics)
+        self.topic_mapper_.add_mappings(sorted_topics, topic_model=self)
 
         # Map documents
         documents.Topic = documents.Topic.map(sorted_topics).fillna(documents.Topic).astype(int)
@@ -4728,11 +4690,12 @@ class TopicMapper:
             mappings = dict(zip(mappings[:, 0], mappings[:, 1]))
         return mappings
 
-    def add_mappings(self, mappings: Mapping[int, int]):
+    def add_mappings(self, mappings: Mapping[int, int], topic_model: BERTopic):
         """Add new column(s) of topic mappings.
 
         Arguments:
             mappings: The mappings to add
+            topic_model: The topic model this TopicMapper belongs to
         """
         for topics in self.mappings_:
             topic = topics[-1]
@@ -4740,6 +4703,50 @@ class TopicMapper:
                 topics.append(mappings[topic])
             else:
                 topics.append(-1)
+
+        # When zero-shot topic(s) are present in the topics to merge,
+        # determine whether to take one of the zero-shot topic labels
+        # or use a calculated representation.
+        if topic_model._is_zeroshot() and len(topic_model._topic_id_to_zeroshot_topic_idx) > 0:
+            new_topic_id_to_zeroshot_topic_idx = {}
+            topics_to_map = {
+                topic_mapping[0]: topic_mapping[1]
+                for topic_mapping in np.array(topic_model.topic_mapper_.mappings_)[:, -2:]
+            }
+
+            # Map topic_to to topics_from
+            mapping = defaultdict(list)
+            for key, value in topics_to_map.items():
+                mapping[value].append(key)
+
+            for topic_to, topics_from in mapping.items():
+                # which of the original topics are zero-shot
+                zeroshot_topic_ids = [
+                    topic_id for topic_id in topics_from if topic_id in topic_model._topic_id_to_zeroshot_topic_idx
+                ]
+                if len(zeroshot_topic_ids) == 0:
+                    continue
+
+                # If any of the original topics are zero-shot, take the best fitting zero-shot label
+                # if the cosine similarity with the new topic exceeds the zero-shot threshold
+                zeroshot_labels = [
+                    topic_model.zeroshot_topic_list[topic_model._topic_id_to_zeroshot_topic_idx[topic_id]]
+                    for topic_id in zeroshot_topic_ids
+                ]
+                zeroshot_embeddings = topic_model._extract_embeddings(zeroshot_labels)
+                cosine_similarities = cosine_similarity(
+                    zeroshot_embeddings, [topic_model.topic_embeddings_[topic_to]]
+                ).flatten()
+                best_zeroshot_topic_idx = np.argmax(cosine_similarities)
+                best_cosine_similarity = cosine_similarities[best_zeroshot_topic_idx]
+
+                if best_cosine_similarity >= topic_model.zeroshot_min_similarity:
+                    # Using the topic ID from before mapping, get the idx into the zeroshot topic list
+                    new_topic_id_to_zeroshot_topic_idx[topic_to] = topic_model._topic_id_to_zeroshot_topic_idx[
+                        zeroshot_topic_ids[best_zeroshot_topic_idx]
+                    ]
+
+            topic_model._topic_id_to_zeroshot_topic_idx = new_topic_id_to_zeroshot_topic_idx
 
     def add_new_topics(self, mappings: Mapping[int, int]):
         """Add new row(s) of topic mappings.

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -4539,20 +4539,8 @@ class BERTopic:
         self._update_topic_size(documents)
         df = pd.DataFrame(self.topic_sizes_.items(), columns=["Old_Topic", "Size"]).sort_values("Size", ascending=False)
         df = df[df.Old_Topic != -1]
-
-        # Zero-shot topics should be after the -1 topic and before clustered topics
-        nr_zeroshot = len(self._topic_id_to_zeroshot_topic_idx)
-        if self._is_zeroshot and not self.nr_topics and nr_zeroshot > 0:
-            df = df.loc[df.Old_Topic.isin([list(range(len(self._topic_id_to_zeroshot_topic_idx)))])]
-            nr_zeroshot = len(self._topic_id_to_zeroshot_topic_idx)
-            sorted_topics = {**{-1: -1}, **dict(zip(df.Old_Topic, range(nr_zeroshot, len(df) + nr_zeroshot)))}
-            for k, v in self._topic_id_to_zeroshot_topic_idx.items():
-                sorted_topics[k] = v
-            self.topic_mapper_.add_mappings(sorted_topics)
-
-        else:
-            sorted_topics = {**{-1: -1}, **dict(zip(df.Old_Topic, range(len(df))))}
-            self.topic_mapper_.add_mappings(sorted_topics)
+        sorted_topics = {**{-1: -1}, **dict(zip(df.Old_Topic, range(len(df))))}
+        self.topic_mapper_.add_mappings(sorted_topics)
 
         # Map documents
         documents.Topic = documents.Topic.map(sorted_topics).fillna(documents.Topic).astype(int)

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3908,6 +3908,7 @@ class BERTopic:
         # Combine the clustered documents/embeddings with assigned documents/embeddings in the original order
         documents = pd.concat([documents, assigned_documents])
         embeddings = np.vstack([embeddings, assigned_embeddings])
+        documents.ID = documents.Old_ID
         sorted_indices = documents.Old_ID.argsort()
         documents = documents.iloc[sorted_indices]
         embeddings = embeddings[sorted_indices]
@@ -4108,10 +4109,7 @@ class BERTopic:
             topic_embeddings = []
             topics = documents.sort_values("Topic").Topic.unique()
             for topic in topics:
-                if self._is_zeroshot():
-                    indices = documents.loc[documents.Topic == topic, "Old_ID"].values
-                else:
-                    indices = documents.loc[documents.Topic == topic, "ID"].values
+                indices = documents.loc[documents.Topic == topic, "ID"].values
                 indices = [int(index) for index in indices]
                 topic_embedding = np.mean(embeddings[indices], axis=0)
                 topic_embeddings.append(topic_embedding)
@@ -4492,11 +4490,11 @@ class BERTopic:
         for key, val in sorted(mapped_topics.items()):
             mappings[val].append(key)
         mappings = {
-            topic_from: {
-                "topics_from": topic_from,
-                "topic_sizes": [self.topic_sizes_[topic] for topic in topics_to],
+            topic_to: {
+                "topics_from": topics_from,
+                "topic_sizes": [self.topic_sizes_[topic] for topic in topics_from],
             }
-            for topics_to, topic_from in mappings.items()
+            for topic_to, topics_from in mappings.items()
         }
 
         # Update documents and topics


### PR DESCRIPTION
# What does this PR do?

Fixes #2102

This fixes a number of things:
* Incorrect ordering of the topic embeddings by using "Old_ID" instead of "ID"
* Unneeded `ValueError` when `nr_topics="auto"` is used combined with zero-shot topic modeling
* Attempting to transform UMAP even when no documents where clustered (only zero-shot topics)
* Add `TopicMapper` at the right moment so that **all** topics are added to the mapper and not only a subset

I updated the way probabilities were returned as I faced some issues with selecting the correct topics. I might change it back after more testing. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes (if applicable)?
- [x] Did you write any new necessary tests?
