### PR TITLE
Fix #2020

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3346,6 +3346,12 @@ class BERTopic:
 
             # Additional
             if save_ctfidf:
+                if self.c_tf_idf_ is None:
+                    logger.warning(
+                        "The c-TF-IDF matrix could not be saved as it was not found. "
+                        "This typically occurs when merging BERTopic models with `BERTopic.merge_models`."
+                    )
+                    return
                 save_utils.save_ctfidf(
                     model=self,
                     save_directory=save_directory,

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3351,13 +3351,13 @@ class BERTopic:
                         "The c-TF-IDF matrix could not be saved as it was not found. "
                         "This typically occurs when merging BERTopic models with `BERTopic.merge_models`."
                     )
-                    return
-                save_utils.save_ctfidf(
-                    model=self,
-                    save_directory=save_directory,
-                    serialization=serialization,
-                )
-                save_utils.save_ctfidf_config(model=self, path=save_directory / "ctfidf_config.json")
+                else:
+                    save_utils.save_ctfidf(
+                        model=self,
+                        save_directory=save_directory,
+                        serialization=serialization,
+                    )
+                    save_utils.save_ctfidf_config(model=self, path=save_directory / "ctfidf_config.json")
 
     @classmethod
     def load(cls, path: str, embedding_model=None):


### PR DESCRIPTION
# What does this PR do?

<!--
Thank you for considering creating a PR! Before you do, make sure to read through [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)
-->

<!-- Remove if not applicable -->

Fixes #2020 

This fix displays a warning if the c-TF-IDF is None when saving the model with `save_ctfidf=True`. This occurs when merging BERTopic models. Before this fix, this would cause a crash as discussed in the issue.

This is my first contribution so please do let me know if I did something wrong or if there any changes required!

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
