### PR TITLE
Fix #2036

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3955,7 +3955,7 @@ class BERTopic:
         # embedding of the seeded topic to force the documents in a cluster
         for seed_topic in range(len(seed_topic_list)):
             indices = [index for index, topic in enumerate(y) if topic == seed_topic]
-            embeddings[indices] = np.average([embeddings[indices], seed_topic_embeddings[seed_topic]], weights=[3, 1])
+            embeddings[indices] = embeddings[indices] * 0.75 + seed_topic_embeddings[seed_topic] * 0.25
         logger.info("Guided - Completed \u2713")
         return y, embeddings
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes `ValueError` when computing weighted average embeddings of seeded topic and documents in the context of Guided Topic Modeling. To solve the issue, direct NumPy array computation is implemented instead of using the `np.average()` function.

Fixes #2036


## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
