### PR TITLE
Update distribution.md

### DIFF
--- a/docs/getting_started/distribution/distribution.md
+++ b/docs/getting_started/distribution/distribution.md
@@ -41,7 +41,7 @@ After doing so, we can approximate the topic distributions for your documents:
 topic_distr, _ = topic_model.approximate_distribution(docs)
 ```
 
-The resulting `topic_distr` is a *n* x *m* matrix where *n* are the topics and *m* the documents. We can then visualize the distribution 
+The resulting `topic_distr` is a *n* x *m* matrix where *n* are the documents and *m* the topics. We can then visualize the distribution 
 of topics in a document:
 
 ```python


### PR DESCRIPTION
topic_distr provides topic scores for each doc, i.e. n- documents and m- topics for each of that doc

# What does this PR do?
There is a documentation typo thats confusing and needs correction.

Eg
```
topic_distr, _ = topic_model.approximate_distribution(documents_array, window=4)

len(topic_distr)#n- number of documents
#output 4172
len(topic_distr[0])#m- number of topics
#output 60
```


<!--
Thank you for considering creating a PR! Before you do, make sure to read through [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)
-->




## Before submitting
- [x] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [ ] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
