### PR TITLE
Fixed issue #2144

### DIFF
--- a/tests/test_representation/test_representations.py
+++ b/tests/test_representation/test_representations.py
@@ -153,6 +153,7 @@ def test_topic_reduction_edge_cases(model, documents, request):
     topics = np.random.randint(-1, nr_topics - 1, len(documents))
     old_documents = pd.DataFrame({"Document": documents, "ID": range(len(documents)), "Topic": topics})
     topic_model._update_topic_size(old_documents)
+    old_documents = topic_model._sort_mappings_by_frequency(old_documents)
     topic_model._extract_topics(old_documents)
     old_freq = topic_model.get_topic_freq()
 


### PR DESCRIPTION
# What does this PR do?
_I'm sorry for making a new PR, but hopefully this is much more clear/clean_

Fixes https://github.com/MaartenGr/BERTopic/issues/2144 (issue) by optimizing the topic extraction process when using fit_transform() with nr_topics="auto" or int for reducing topics. The main improvements are:

- Avoiding double calculation of topic representations, especially when using LLM-based representations.
- Modifying the fit_transform method to extract_topics only after topic reduction (if needed).
    **On my previous PR I added a `calculate representations` argument. This is not necessary here, as the initial nr of topics is now retrieved as `initial_nr_topics = len(documents["Topic"].unique())`, which is an outcome of the clustering procedure. So this doesn't require a previous call on `extract_topics()`, in any form**.
- These changes significantly improve performance, particularly when using computationally expensive representation models like LLMs along avoiding double c-TF-IDF calculation.

Additionally, this PR addresses an edge case where self.nr_topics >= initial_nr_topics by adding self._sort_mappings_by_frequency(documents) in def _reduce_topics() in line 4369. This was not accounted with previous tests (they raised a false negative), so test_representations.py was modified to account for this.

Before submitting
- [x] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x]  Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x]  Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x]  Did you make sure to update the documentation with your changes (if applicable)?
- [x]  Did you write any new necessary tests?
      - Modified test_representations to account for the edge case mentioned above