### PR TITLE
Remove duplicated phrase "the model" 

### DIFF
--- a/docs/getting_started/representation/llm.md
+++ b/docs/getting_started/representation/llm.md
@@ -334,7 +334,7 @@ After installation, you need to download your LLM locally before we use it in BE
 wget https://huggingface.co/TheBloke/zephyr-7B-alpha-GGUF/resolve/main/zephyr-7b-alpha.Q4_K_M.gguf
 ```
 
-Finally, we can now use the model the model with BERTopic in just a couple of lines:
+Finally, we can now use the model with BERTopic in just a couple of lines:
 
 ```python
 from bertopic import BERTopic


### PR DESCRIPTION
I didn't create an issue because this is really a small fix. Just removed the duplicated "the model" phase in the llm.md content.