### PR TITLE
fix: handling OpenAI returning None objects

### DIFF
--- a/bertopic/representation/_openai.py
+++ b/bertopic/representation/_openai.py
@@ -245,7 +245,8 @@ class OpenAI(BaseRepresentation):
 
                 # Check whether content was actually generated
                 # Addresses #1570 for potential issues with OpenAI's content filter
-                if hasattr(response.choices[0].message, "content"):
+                # Addresses #2176 for potential issues when openAI returns a None type object
+                if response and hasattr(response.choices[0].message, "content"):
                     label = response.choices[0].message.content.strip().replace("topic: ", "")
                 else:
                     label = "No label returned"


### PR DESCRIPTION
# What does this PR do?

<!--
Thank you for considering creating a PR! Before you do, make sure to read through [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)
-->

<!-- Remove if not applicable -->

Fixes #2176
OpenAI sometimes returns a None type object instead of a response object. This could happen when you, for instance, run into a rate limit issue or a content violation error. To prevent the whole run to fail, a check is added if the response object is not of type None, if the object is of type None, the label for that specific topic is set to "No label returned". This approach of handling an issue when generating the label for a topic was chosen in a previous iteration and is kept as is.

No documentation has been added with this PR since this is a very minor fix that doesn't influence documentation. There has been a comment added to the code in line with a previously iteration done to the code.
No tests have been added.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
