### PR TITLE
Lightweight installation: use safetensors without torch

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -4856,7 +4856,6 @@ def _create_model_from_files(
         ctfidf_config["vectorizer_model"]["params"]["ngram_range"] = tuple(ngram_range)
 
     params["n_gram_range"] = tuple(params["n_gram_range"])
-    ctfidf_config
 
     # Select HF model through SentenceTransformers
     try:
@@ -4888,10 +4887,7 @@ def _create_model_from_files(
         **params,
     )
     # converting torch.Tensors to numpy without referencing torch
-    if isinstance(tensors["topic_embeddings"], np.ndarray):
-        topic_model.topic_embeddings_ = tensors["topic_embeddings"]
-    else:
-        topic_model.topic_embeddings_ = tensors["topic_embeddings"].numpy()
+    topic_model.topic_embeddings_ = tensors["topic_embeddings"]
     topic_model.topic_representations_ = {int(key): val for key, val in topics["topic_representations"].items()}
     topic_model.topics_ = topics["topics"]
     topic_model.topic_sizes_ = {int(key): val for key, val in topics["topic_sizes"].items()}

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -4887,7 +4887,9 @@ def _create_model_from_files(
         hdbscan_model=empty_cluster_model,
         **params,
     )
-    topic_model.topic_embeddings_ = tensors["topic_embeddings"]
+    # converting torch.Tensors to numpy without referencing torch
+    topic_model.topic_embeddings_ = tensors["topic_embeddings"] \
+        if isinstance(tensors["topic_embeddings"], np.ndarray) else tensors["topic_embeddings"].numpy()
     topic_model.topic_representations_ = {int(key): val for key, val in topics["topic_representations"].items()}
     topic_model.topics_ = topics["topics"]
     topic_model.topic_sizes_ = {int(key): val for key, val in topics["topic_sizes"].items()}

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -4886,7 +4886,6 @@ def _create_model_from_files(
         hdbscan_model=empty_cluster_model,
         **params,
     )
-    # converting torch.Tensors to numpy without referencing torch
     topic_model.topic_embeddings_ = tensors["topic_embeddings"]
     topic_model.topic_representations_ = {int(key): val for key, val in topics["topic_representations"].items()}
     topic_model.topics_ = topics["topics"]

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -4849,7 +4849,6 @@ def _create_model_from_files(
         images: The images per topic
         warn_no_backend: Whether to warn the user if no backend is given
     """
-    from sentence_transformers import SentenceTransformer
 
     params["n_gram_range"] = tuple(params["n_gram_range"])
 
@@ -4862,6 +4861,7 @@ def _create_model_from_files(
 
     # Select HF model through SentenceTransformers
     try:
+        from sentence_transformers import SentenceTransformer
         embedding_model = select_backend(SentenceTransformer(params["embedding_model"]))
     except:  # noqa: E722
         embedding_model = BaseEmbedder()
@@ -4887,7 +4887,7 @@ def _create_model_from_files(
         hdbscan_model=empty_cluster_model,
         **params,
     )
-    topic_model.topic_embeddings_ = tensors["topic_embeddings"].numpy()
+    topic_model.topic_embeddings_ = tensors["topic_embeddings"]
     topic_model.topic_representations_ = {int(key): val for key, val in topics["topic_representations"].items()}
     topic_model.topics_ = topics["topics"]
     topic_model.topic_sizes_ = {int(key): val for key, val in topics["topic_sizes"].items()}
@@ -4924,7 +4924,7 @@ def _create_model_from_files(
         # ClassTfidfTransformer
         topic_model.ctfidf_model.reduce_frequent_words = ctfidf_config["ctfidf_model"]["reduce_frequent_words"]
         topic_model.ctfidf_model.bm25_weighting = ctfidf_config["ctfidf_model"]["bm25_weighting"]
-        idf = ctfidf_tensors["diag"].numpy()
+        idf = ctfidf_tensors["diag"]
         topic_model.ctfidf_model._idf_diag = sp.diags(
             idf, offsets=0, shape=(len(idf), len(idf)), format="csr", dtype=np.float64
         )

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -4849,7 +4849,6 @@ def _create_model_from_files(
         images: The images per topic
         warn_no_backend: Whether to warn the user if no backend is given
     """
-
     params["n_gram_range"] = tuple(params["n_gram_range"])
 
     if ctfidf_config is not None:
@@ -4862,6 +4861,7 @@ def _create_model_from_files(
     # Select HF model through SentenceTransformers
     try:
         from sentence_transformers import SentenceTransformer
+
         embedding_model = select_backend(SentenceTransformer(params["embedding_model"]))
     except:  # noqa: E722
         embedding_model = BaseEmbedder()
@@ -4888,8 +4888,10 @@ def _create_model_from_files(
         **params,
     )
     # converting torch.Tensors to numpy without referencing torch
-    topic_model.topic_embeddings_ = tensors["topic_embeddings"] \
-        if isinstance(tensors["topic_embeddings"], np.ndarray) else tensors["topic_embeddings"].numpy()
+    if isinstance(tensors["topic_embeddings"], np.ndarray):
+        topic_model.topic_embeddings_ = tensors["topic_embeddings"]
+    else:
+        topic_model.topic_embeddings_ = tensors["topic_embeddings"].numpy()
     topic_model.topic_representations_ = {int(key): val for key, val in topics["topic_representations"].items()}
     topic_model.topics_ = topics["topics"]
     topic_model.topic_sizes_ = {int(key): val for key, val in topics["topic_sizes"].items()}

--- a/bertopic/_save_utils.py
+++ b/bertopic/_save_utils.py
@@ -328,11 +328,11 @@ def save_hf(model, save_directory, serialization: str):
 
 def save_ctfidf(model, save_directory: str, serialization: str):
     """Save c-TF-IDF sparse matrix."""
-    indptr = torch.from_numpy(model.c_tf_idf_.indptr)
-    indices = torch.from_numpy(model.c_tf_idf_.indices)
-    data = torch.from_numpy(model.c_tf_idf_.data)
-    shape = torch.from_numpy(np.array(model.c_tf_idf_.shape))
-    diag = torch.from_numpy(np.array(model.ctfidf_model._idf_diag.data))
+    indptr = model.c_tf_idf_.indptr
+    indices = model.c_tf_idf_.indices
+    data = model.c_tf_idf_.data
+    shape = np.array(model.c_tf_idf_.shape)
+    diag = np.array(model.ctfidf_model._idf_diag.data)
 
     if serialization == "safetensors":
         tensors = {

--- a/bertopic/_save_utils.py
+++ b/bertopic/_save_utils.py
@@ -185,6 +185,7 @@ def load_local_files(path):
         torch_path = path / HF_WEIGHTS_NAME
         if torch_path.is_file():
             tensors = torch.load(torch_path, map_location="cpu")
+            tensors = {k: v.numpy() for k, v in tensors.items()}
 
     # c-TF-IDF
     try:
@@ -196,6 +197,7 @@ def load_local_files(path):
             torch_path = path / CTFIDF_WEIGHTS_NAME
             if torch_path.is_file():
                 ctfidf_tensors = torch.load(torch_path, map_location="cpu")
+                ctfidf_tensors = {k: v.numpy() for k, v in ctfidf_tensors.items()}
         ctfidf_config = load_cfg_from_json(path / CTFIDF_CFG_NAME)
     except:  # noqa: E722
         ctfidf_config, ctfidf_tensors = None, None

--- a/bertopic/_save_utils.py
+++ b/bertopic/_save_utils.py
@@ -184,7 +184,7 @@ def load_local_files(path):
     else:
         torch_path = path / HF_WEIGHTS_NAME
         if torch_path.is_file():
-            tensors = torch.load(torch_path, map_location="cpu")
+            tensors = torch.load(torch_path, map_location="cpu").numpy()
 
     # c-TF-IDF
     try:
@@ -195,7 +195,7 @@ def load_local_files(path):
         else:
             torch_path = path / CTFIDF_WEIGHTS_NAME
             if torch_path.is_file():
-                ctfidf_tensors = torch.load(torch_path, map_location="cpu")
+                ctfidf_tensors = torch.load(torch_path, map_location="cpu").numpy()
         ctfidf_config = load_cfg_from_json(path / CTFIDF_CFG_NAME)
     except:  # noqa: E722
         ctfidf_config, ctfidf_tensors = None, None
@@ -233,7 +233,7 @@ def load_files_from_hf(path):
         tensors = load_safetensors(tensors)
     except:  # noqa: E722
         tensors = hf_hub_download(path, HF_WEIGHTS_NAME, revision=None)
-        tensors = torch.load(tensors, map_location="cpu")
+        tensors = torch.load(tensors, map_location="cpu").numpy()
 
     # c-TF-IDF
     try:
@@ -243,7 +243,7 @@ def load_files_from_hf(path):
             ctfidf_tensors = load_safetensors(ctfidf_tensors)
         except:  # noqa: E722
             ctfidf_tensors = hf_hub_download(path, CTFIDF_WEIGHTS_NAME, revision=None)
-            ctfidf_tensors = torch.load(ctfidf_tensors, map_location="cpu")
+            ctfidf_tensors = torch.load(ctfidf_tensors, map_location="cpu").numpy()
     except:  # noqa: E722
         ctfidf_config, ctfidf_tensors = None, None
 
@@ -511,10 +511,9 @@ def get_package_versions():
 def load_safetensors(path):
     """Load safetensors and check whether it is installed."""
     try:
-        import safetensors.torch
-        import safetensors
+        import safetensors.numpy
 
-        return safetensors.torch.load_file(path, device="cpu")
+        return safetensors.numpy.load_file(path)
     except ImportError:
         raise ValueError("`pip install safetensors` to load .safetensors")
 


### PR DESCRIPTION
# What does this PR do?

This PR removes unnecessary imports of torch from model load/save code to enable lightweight installation (without torch) as described [here in docs](https://maartengr.github.io/BERTopic/getting_started/tips_and_tricks/tips_and_tricks.html#lightweight-installation).

It achieves this mainly by replacing calls to `safetensors.torch.[save|load]_file()` with `safetensors.numpy.[save|load]_file()`, and removing other calls to torch methods. 


Fixes #2304


## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
