### PR TITLE
Merge models without pytorch (using safetensors)

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3488,14 +3488,17 @@ class BERTopic:
         merged_model = BERTopic.merge_models([topic_model_1, topic_model_2, topic_model_3])
         ```
         """
+
         def choose_backend():
             """Choose the backend to use for saving the model."""
             try:
                 import torch  # noqa: F401
+
                 return "pytorch"
             except (ModuleNotFoundError, ImportError):
                 try:
                     import safetensors  # noqa: F401
+
                     return "safetensors"
                 except (ModuleNotFoundError, ImportError):
                     raise ImportError(


### PR DESCRIPTION
# What does this PR do?

<!--
Thank you for considering creating a PR! Before you do, make sure to read through [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)
-->

<!-- Remove if not applicable -->

Fixes #2326

Allows the use of `merge_models` with either `safetensors` or `pytorch`. It chooses the backend automatically but defaults to PyTorch if it is installed. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
