### PR TITLE
fix incorrect comparison in update_topics MaartenGr/BERTopic#2332

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -1574,7 +1574,7 @@ class BERTopic:
         self.topic_representations_ = self._extract_words_per_topic(words, documents)
 
         # Update topic vectors
-        if set(topics) != self.topics_:
+        if set(topics) != set(self.topics_):
             # Remove outlier topic embedding if all that has changed is the outlier class
             same_position = all(
                 [

--- a/tests/test_bertopic.py
+++ b/tests/test_bertopic.py
@@ -152,5 +152,4 @@ def test_full_model(model, documents, request):
     topic_model1 = BERTopic.load("model_dir")
     merged_model = BERTopic.merge_models([topic_model, topic_model1])
 
-    assert len(merged_model.get_topic_info()) > len(topic_model1.get_topic_info())
     assert len(merged_model.get_topic_info()) > len(topic_model.get_topic_info())


### PR DESCRIPTION
# What does this PR do?
Fixes #2332

## Changes Made
Modified the topic comparison logic in `_bertopic.py` from using set comparison `set(topics) != self.topics_` to direct comparison `topics != self.topics_`. This change affects how topic updates are handled during the `update_topics()` method.

## Technical Details
### Previous Behavior
- The set comparison `set(topics) != self.topics_` would trigger  unnecessary recalculations in `_create_topic_vectors` when the topic set remained the same

### Current Behavior
- The direct comparison `set(topics) != set(self.topics_)` is more precise
- Topic embedding recalculation only occurs when there's an actual change in topic set

## Impact on Testing
The change affects test cases in `test_bertopic.py` where `update_topics()` is called twice, which will lead to different result of `merge_models` 
        



## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
