### PR TITLE
Modify reduce_dimensionality to use fit_transform

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3784,7 +3784,7 @@ class BERTopic:
             if hasattr(self.umap_model, "partial_fit"):
                 self.umap_model = self.umap_model.partial_fit(embeddings)
                 umap_embeddings = self.umap_model.transform(embeddings)
-            elif self.topic_representations_ is None:
+            else:
                 if hasattr(self.umap_model, "fit_transform"):
                     umap_embeddings = self.umap_model.fit_transform(embeddings, y=y)
                 else:

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3784,14 +3784,18 @@ class BERTopic:
             if hasattr(self.umap_model, "partial_fit"):
                 self.umap_model = self.umap_model.partial_fit(embeddings)
                 umap_embeddings = self.umap_model.transform(embeddings)
-            elif self.topic_representations_ is None:
+            else:
                 umap_embeddings = self.umap_model.fit_transform(embeddings)
 
         # Regular fit
         else:
-            # cuml umap needs y to be an numpy array
-            y = np.array(y) if y is not None else None
-            umap_embeddings = self.umap_model.fit_transform(embeddings, y=y)
+            try:
+                # cuml umap needs y to be an numpy array
+                y = np.array(y) if y is not None else None
+                umap_embeddings = self.umap_model.fit_transform(embeddings, y=y)
+            except TypeError:
+                self.umap_model.fit(embeddings)
+                umap_embeddings = self.umap_model.fit_transform(embeddings)
         
         logger.info("Dimensionality - Completed \u2713")
         return np.nan_to_num(umap_embeddings)

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3784,18 +3784,29 @@ class BERTopic:
             if hasattr(self.umap_model, "partial_fit"):
                 self.umap_model = self.umap_model.partial_fit(embeddings)
                 umap_embeddings = self.umap_model.transform(embeddings)
-            else:
-                umap_embeddings = self.umap_model.fit_transform(embeddings)
+            elif self.topic_representations_ is None:
+                if hasattr(self.umap_model, "fit_transform"):
+                    umap_embeddings = self.umap_model.fit_transform(embeddings, y=y)
+                else:
+                    self.umap_model.fit(embeddings)
+                    umap_embeddings = self.umap_model.transform(embeddings)
 
         # Regular fit
         else:
             try:
                 # cuml umap needs y to be an numpy array
                 y = np.array(y) if y is not None else None
-                umap_embeddings = self.umap_model.fit_transform(embeddings, y=y)
+                if hasattr(self.umap_model, "fit_transform"):
+                    umap_embeddings = self.umap_model.fit_transform(embeddings, y=y)
+                else:
+                    self.umap_model.fit(embeddings)
+                    umap_embeddings = self.umap_model.transform(embeddings)
             except TypeError:
-                self.umap_model.fit(embeddings)
-                umap_embeddings = self.umap_model.fit_transform(embeddings)
+                if hasattr(self.umap_model, "fit_transform"):
+                    umap_embeddings = self.umap_model.fit_transform(embeddings)
+                else:
+                    self.umap_model.fit(embeddings)
+                    umap_embeddings = self.umap_model.transform(embeddings)
         
         logger.info("Dimensionality - Completed \u2713")
         return np.nan_to_num(umap_embeddings)

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3783,19 +3783,19 @@ class BERTopic:
         if partial_fit:
             if hasattr(self.umap_model, "partial_fit"):
                 self.umap_model = self.umap_model.partial_fit(embeddings)
+                umap_embeddings = self.umap_model.transform(embeddings)
             elif self.topic_representations_ is None:
-                self.umap_model.fit(embeddings)
+                umap_embeddings = self.umap_model.fit_transform(embeddings)
 
         # Regular fit
         else:
             try:
                 # cuml umap needs y to be an numpy array
                 y = np.array(y) if y is not None else None
-                self.umap_model.fit(embeddings, y=y)
+                umap_embeddings = self.umap_model.fit_transform(embeddings, y=y)
             except TypeError:
-                self.umap_model.fit(embeddings)
+                umap_embeddings = self.umap_model.fit_transform(embeddings)
 
-        umap_embeddings = self.umap_model.transform(embeddings)
         logger.info("Dimensionality - Completed \u2713")
         return np.nan_to_num(umap_embeddings)
 

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3789,15 +3789,9 @@ class BERTopic:
 
         # Regular fit
         else:
-            try:
-                # cuml umap needs y to be an numpy array
-                y = np.array(y) if y is not None else None
-                umap_embeddings = self.umap_model.fit_transform(embeddings, y=y)
-            except TypeError:
-                umap_embeddings = self.umap_model.fit_transform(embeddings)
-
-        if not umap_embeddings:
-            umap_embeddings = self.umap_model.transform(embeddings)
+            # cuml umap needs y to be an numpy array
+            y = np.array(y) if y is not None else None
+            umap_embeddings = self.umap_model.fit_transform(embeddings, y=y)
         
         logger.info("Dimensionality - Completed \u2713")
         return np.nan_to_num(umap_embeddings)

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3807,7 +3807,7 @@ class BERTopic:
                 else:
                     self.umap_model.fit(embeddings)
                     umap_embeddings = self.umap_model.transform(embeddings)
-        
+
         logger.info("Dimensionality - Completed \u2713")
         return np.nan_to_num(umap_embeddings)
 

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3784,9 +3784,12 @@ class BERTopic:
             if hasattr(self.umap_model, "partial_fit"):
                 self.umap_model = self.umap_model.partial_fit(embeddings)
                 umap_embeddings = self.umap_model.transform(embeddings)
+            elif self.topic_representations_ is None:
+                self.umap_model.fit(embeddings)
+                umap_embeddings = self.umap_model.transform(embeddings)
             else:
                 if hasattr(self.umap_model, "fit_transform"):
-                    umap_embeddings = self.umap_model.fit_transform(embeddings, y=y)
+                    umap_embeddings = self.umap_model.fit_transform(embeddings)
                 else:
                     self.umap_model.fit(embeddings)
                     umap_embeddings = self.umap_model.transform(embeddings)
@@ -3800,7 +3803,7 @@ class BERTopic:
                     umap_embeddings = self.umap_model.fit_transform(embeddings, y=y)
                 else:
                     self.umap_model.fit(embeddings)
-                    umap_embeddings = self.umap_model.transform(embeddings)
+                    umap_embeddings = self.umap_model.transform(embeddings, y=y)
             except TypeError:
                 if hasattr(self.umap_model, "fit_transform"):
                     umap_embeddings = self.umap_model.fit_transform(embeddings)

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -3796,6 +3796,9 @@ class BERTopic:
             except TypeError:
                 umap_embeddings = self.umap_model.fit_transform(embeddings)
 
+        if not umap_embeddings:
+            umap_embeddings = self.umap_model.transform(embeddings)
+        
         logger.info("Dimensionality - Completed \u2713")
         return np.nan_to_num(umap_embeddings)
 


### PR DESCRIPTION
Modifying _reduce_dimensionality to use fit_transform in single step, supporting the use of nearest neighbor descent when using cuML UMAP.


Fixes [#2335](https://github.com/MaartenGr/BERTopic/issues/2335)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [X] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [X] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
-   [Adding support for cuML's nn-descent with UMAP](https://github.com/MaartenGr/BERTopic/issues/2335)
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
