### PR TITLE
Update to pass precomputed embeddings to KeyBERTInspired.extract_topics

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -59,7 +59,7 @@ from bertopic.backend import BaseEmbedder
 from bertopic.representation._mmr import mmr
 from bertopic.backend._utils import select_backend
 from bertopic.vectorizers import ClassTfidfTransformer
-from bertopic.representation import BaseRepresentation, KeyBERTInspired, MaximalMarginalRelevance
+from bertopic.representation import BaseRepresentation, KeyBERTInspired
 from bertopic.dimensionality import BaseDimensionalityReduction
 from bertopic.cluster._utils import hdbscan_delegator, is_supported_hdbscan
 from bertopic._utils import (
@@ -4365,7 +4365,7 @@ class BERTopic:
         elif fine_tune_representation and isinstance(self.representation_model, list):
             for tuner in self.representation_model:
                 topics = tuner.extract_topics(self, documents, c_tf_idf, topics)
-        elif fine_tune_representation and isinstance(self.representation_model, (KeyBERTInspired, MaximalMarginalRelevance)):
+        elif fine_tune_representation and isinstance(self.representation_model, KeyBERTInspired):
             topics = self.representation_model.extract_topics(self, documents, c_tf_idf, topics, embeddings)
         elif fine_tune_representation and isinstance(self.representation_model, BaseRepresentation):
             topics = self.representation_model.extract_topics(self, documents, c_tf_idf, topics)

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -59,7 +59,7 @@ from bertopic.backend import BaseEmbedder
 from bertopic.representation._mmr import mmr
 from bertopic.backend._utils import select_backend
 from bertopic.vectorizers import ClassTfidfTransformer
-from bertopic.representation import BaseRepresentation
+from bertopic.representation import BaseRepresentation, KeyBERTInspired
 from bertopic.dimensionality import BaseDimensionalityReduction
 from bertopic.cluster._utils import hdbscan_delegator, is_supported_hdbscan
 from bertopic._utils import (
@@ -4365,8 +4365,10 @@ class BERTopic:
         elif fine_tune_representation and isinstance(self.representation_model, list):
             for tuner in self.representation_model:
                 topics = tuner.extract_topics(self, documents, c_tf_idf, topics)
-        elif fine_tune_representation and isinstance(self.representation_model, BaseRepresentation):
+        elif fine_tune_representation and isinstance(self.representation_model, KeyBERTInspired):
             topics = self.representation_model.extract_topics(self, documents, c_tf_idf, topics, embeddings)
+        elif fine_tune_representation and isinstance(self.representation_model, BaseRepresentation):
+            topics = self.representation_model.extract_topics(self, documents, c_tf_idf, topics)
         elif fine_tune_representation and isinstance(self.representation_model, dict):
             if self.representation_model.get("Main"):
                 main_model = self.representation_model["Main"]

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -4051,6 +4051,7 @@ class BERTopic:
             documents,
             fine_tune_representation=fine_tune_representation,
             calculate_aspects=fine_tune_representation,
+            embeddings=embeddings,
         )
         self._create_topic_vectors(documents=documents, embeddings=embeddings, mappings=mappings)
 
@@ -4311,6 +4312,7 @@ class BERTopic:
         c_tf_idf: csr_matrix = None,
         fine_tune_representation: bool = True,
         calculate_aspects: bool = True,
+        embeddings: np.ndarray = None,
     ) -> Mapping[str, List[Tuple[str, float]]]:
         """Based on tf_idf scores per topic, extract the top n words per topic.
 
@@ -4362,7 +4364,7 @@ class BERTopic:
             for tuner in self.representation_model:
                 topics = tuner.extract_topics(self, documents, c_tf_idf, topics)
         elif fine_tune_representation and isinstance(self.representation_model, BaseRepresentation):
-            topics = self.representation_model.extract_topics(self, documents, c_tf_idf, topics)
+            topics = self.representation_model.extract_topics(self, documents, c_tf_idf, topics, embeddings)
         elif fine_tune_representation and isinstance(self.representation_model, dict):
             if self.representation_model.get("Main"):
                 main_model = self.representation_model["Main"]

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -4328,6 +4328,8 @@ class BERTopic:
             fine_tune_representation: If True, the topic representation will be fine-tuned using representation models.
                                       If False, the topic representation will remain as the base c-TF-IDF representation.
             calculate_aspects: Whether to calculate additional topic aspects
+            embeddings: Pre-trained document embeddings. These can be used
+                        instead of the sentence-transformer model
 
         Returns:
             topics: The top words per topic

--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -59,7 +59,7 @@ from bertopic.backend import BaseEmbedder
 from bertopic.representation._mmr import mmr
 from bertopic.backend._utils import select_backend
 from bertopic.vectorizers import ClassTfidfTransformer
-from bertopic.representation import BaseRepresentation, KeyBERTInspired
+from bertopic.representation import BaseRepresentation, KeyBERTInspired, MaximalMarginalRelevance
 from bertopic.dimensionality import BaseDimensionalityReduction
 from bertopic.cluster._utils import hdbscan_delegator, is_supported_hdbscan
 from bertopic._utils import (
@@ -4329,7 +4329,7 @@ class BERTopic:
                                       If False, the topic representation will remain as the base c-TF-IDF representation.
             calculate_aspects: Whether to calculate additional topic aspects
             embeddings: Pre-trained document embeddings. These can be used
-                        instead of the sentence-transformer model
+                        instead of an embedding model
 
         Returns:
             topics: The top words per topic
@@ -4365,7 +4365,7 @@ class BERTopic:
         elif fine_tune_representation and isinstance(self.representation_model, list):
             for tuner in self.representation_model:
                 topics = tuner.extract_topics(self, documents, c_tf_idf, topics)
-        elif fine_tune_representation and isinstance(self.representation_model, KeyBERTInspired):
+        elif fine_tune_representation and isinstance(self.representation_model, (KeyBERTInspired, MaximalMarginalRelevance)):
             topics = self.representation_model.extract_topics(self, documents, c_tf_idf, topics, embeddings)
         elif fine_tune_representation and isinstance(self.representation_model, BaseRepresentation):
             topics = self.representation_model.extract_topics(self, documents, c_tf_idf, topics)

--- a/bertopic/representation/_keybert.py
+++ b/bertopic/representation/_keybert.py
@@ -184,7 +184,7 @@ class KeyBERTInspired(BaseRepresentation):
             repr_embeddings = topic_model._extract_embeddings(representative_docs, method="document", verbose=False)
 
         topic_embeddings = [np.mean(repr_embeddings[i[0] : i[-1] + 1], axis=0) for i in repr_doc_indices]
-        
+
         # Calculate word embeddings and extract best matching with updated topic_embeddings
         vocab = list(set([word for words in topics.values() for word in words]))
         word_embeddings = topic_model._extract_embeddings(vocab, method="document", verbose=False)

--- a/bertopic/representation/_keybert.py
+++ b/bertopic/representation/_keybert.py
@@ -101,8 +101,9 @@ class KeyBERTInspired(BaseRepresentation):
 
         # We calculate the similarity between word and document embeddings and create
         # topic embeddings from the representative document embeddings
-        sim_matrix, words = self._extract_embeddings(topic_model, topics, representative_docs, repr_doc_indices,repr_embeddings)
-
+        sim_matrix, words = self._extract_embeddings(
+             topic_model, topics, representative_docs, repr_doc_indices, repr_embeddings
+         )
         # Find the best matching words based on the similarity matrix for each topic
         updated_topics = self._extract_top_words(words, topics, sim_matrix)
 

--- a/bertopic/representation/_keybert.py
+++ b/bertopic/representation/_keybert.py
@@ -81,7 +81,7 @@ class KeyBERTInspired(BaseRepresentation):
             c_tf_idf: The topic c-TF-IDF representation
             topics: The candidate topics as calculated with c-TF-IDF
             embeddings: Pre-trained document embeddings. These can be used
-                        instead of the sentence-transformer model
+                        instead of an embedding model
 
         Returns:
             updated_topics: Updated topic representations
@@ -91,7 +91,7 @@ class KeyBERTInspired(BaseRepresentation):
             c_tf_idf, documents, topics, self.nr_samples, self.nr_repr_docs
         )
 
-        # If document embeddings are precomputed extract the embeddings of the represenantative documents based on repr_doc_indices
+        # If document embeddings are precomputed, extract the embeddings of the representative documents based on repr_doc_indices
         repr_embeddings = None
         if embeddings is not None:
             repr_embeddings = [embeddings[index] for index in np.concatenate(repr_doc_indices)]
@@ -178,8 +178,7 @@ class KeyBERTInspired(BaseRepresentation):
             sim: The similarity matrix between word and topic embeddings
             vocab: The complete vocabulary of input documents
         """
-        # Calculate representative docs embeddings and create topic embeddings
-        # If there are no precomputed embeddings, only then create embeddings
+        # Calculate representative document embeddings if there are no precomputed embeddings.
         if repr_embeddings is None:
             repr_embeddings = topic_model._extract_embeddings(representative_docs, method="document", verbose=False)
 

--- a/bertopic/representation/_keybert.py
+++ b/bertopic/representation/_keybert.py
@@ -184,7 +184,6 @@ class KeyBERTInspired(BaseRepresentation):
             repr_embeddings = topic_model._extract_embeddings(representative_docs, method="document", verbose=False)
 
         topic_embeddings = [np.mean(repr_embeddings[i[0] : i[-1] + 1], axis=0) for i in repr_doc_indices]
-
         
         # Calculate word embeddings and extract best matching with updated topic_embeddings
         vocab = list(set([word for words in topics.values() for word in words]))

--- a/bertopic/representation/_keybert.py
+++ b/bertopic/representation/_keybert.py
@@ -102,8 +102,8 @@ class KeyBERTInspired(BaseRepresentation):
         # We calculate the similarity between word and document embeddings and create
         # topic embeddings from the representative document embeddings
         sim_matrix, words = self._extract_embeddings(
-             topic_model, topics, representative_docs, repr_doc_indices, repr_embeddings
-         )
+            topic_model, topics, representative_docs, repr_doc_indices, repr_embeddings
+        )
         # Find the best matching words based on the similarity matrix for each topic
         updated_topics = self._extract_top_words(words, topics, sim_matrix)
 

--- a/bertopic/representation/_keybert.py
+++ b/bertopic/representation/_keybert.py
@@ -183,8 +183,8 @@ class KeyBERTInspired(BaseRepresentation):
         if repr_embeddings is None:
             repr_embeddings = topic_model._extract_embeddings(representative_docs, method="document", verbose=False)
 
-        
         topic_embeddings = [np.mean(repr_embeddings[i[0] : i[-1] + 1], axis=0) for i in repr_doc_indices]
+
         
         # Calculate word embeddings and extract best matching with updated topic_embeddings
         vocab = list(set([word for words in topics.values() for word in words]))

--- a/bertopic/representation/_keybert.py
+++ b/bertopic/representation/_keybert.py
@@ -180,7 +180,6 @@ class KeyBERTInspired(BaseRepresentation):
         # Calculate representative docs embeddings and create topic embeddings
         # If there are no precomputed embeddings, only then create embeddings
         if repr_embeddings is None:
-            logger.info("Embedding - Transforming representative documents to embeddings.")
             repr_embeddings = topic_model._extract_embeddings(representative_docs, method="document", verbose=False)
         
         topic_embeddings = [np.mean(repr_embeddings[i[0] : i[-1] + 1], axis=0) for i in repr_doc_indices]

--- a/bertopic/representation/_keybert.py
+++ b/bertopic/representation/_keybert.py
@@ -182,9 +182,10 @@ class KeyBERTInspired(BaseRepresentation):
         # If there are no precomputed embeddings, only then create embeddings
         if repr_embeddings is None:
             repr_embeddings = topic_model._extract_embeddings(representative_docs, method="document", verbose=False)
+
         
         topic_embeddings = [np.mean(repr_embeddings[i[0] : i[-1] + 1], axis=0) for i in repr_doc_indices]
-
+        
         # Calculate word embeddings and extract best matching with updated topic_embeddings
         vocab = list(set([word for words in topics.values() for word in words]))
         word_embeddings = topic_model._extract_embeddings(vocab, method="document", verbose=False)


### PR DESCRIPTION
# What does this PR do?

This PR essentially passes the precomputed embeddings to extract_topics method of KeyBERTInspired to avoid re computing embeddings of documents.

<!--
Thank you for considering creating a PR! Before you do, make sure to read through [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)
-->

<!-- Remove if not applicable -->

Fixes # https://github.com/MaartenGr/BERTopic/issues/2367


## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
