### PR TITLE
Fix typo in Lightweight installation under tips_and_tricks

### DIFF
--- a/docs/getting_started/tips_and_tricks/tips_and_tricks.md
+++ b/docs/getting_started/tips_and_tricks/tips_and_tricks.md
@@ -207,7 +207,7 @@ This installs a bare-bones version of BERTopic. If you want to use UMAP and Mode
 
 `pip install model2vec umap-learn`
 
-Then, you can BERTopic without needing to have a CPU:
+Then, you can BERTopic without needing to have a GPU:
 
 ```python
 from bertopic import BERTopic


### PR DESCRIPTION
# What does this PR do?

This PR fixes a typo under the **Lightweight installation** subsection in the **Tips and Tricks** page.

Fixes 
Replaced the following phrase: "Then, you can BERTopic without needing to have a CPU" with "Then, you can BERTopic without needing to have a GPU".


## Before submitting
- [✅ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [ ] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
