### PR TITLE
Hard dependency to prevent conflicts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,8 +5,13 @@ hide:
 
 # Changelog
 
+## **Version 0.17.3**
+*Release date: 8 July, 2025*
 
-## **Version 0.17.0**
+* Fixed issues with `uv add bertopic` by adding `llvmlite` as an explicit dependency. Although the fixes in `v0.17.2` and `v0.17.2.post1` actually worked locally, this wasn't the case after pushing the package to pypi.org unfortunately.
+
+
+## **Version 0.17.1**
 *Release date: 8 July, 2025*
 
 <h3><b>Highlights:</a></b></h3>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bertopic"
-version = "0.17.2.post1"
+version = "0.17.3"
 description = "BERTopic performs topic Modeling with state-of-the-art transformer models."
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -45,6 +45,7 @@ dependencies = [
     "scikit-learn>=1.0",
     "sentence-transformers>=0.4.1",
     "tqdm>=4.41.1",
+    "llvmlite>0.36.0"  # To prevent conflicts with `uv` dependency manager
 ]
 
 [project.optional-dependencies]
@@ -99,10 +100,6 @@ Repository = "https://github.com/MaartenGr/BERTopic.git"
 [tool.setuptools.packages.find]
 include = ["bertopic*"]
 exclude = ["tests"]
-
-[tool.uv]
-constraint-dependencies = ["llvmlite>0.43.0"]
-build-constraint-dependencies = ["llvmlite>0.43.0"]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Alright, this was more annoying than I'd expected.

It turns out that `llvmlite` gives major issues with `uv`'s dependency manager (see https://github.com/MaartenGr/BERTopic/issues/2311).

I initially thought that adding the following would work:

```
[tool.uv]
constraint-dependencies = ["llvm>0.43.0"]
```

Which it did during local tests. However, it seemed that this was not the case after pushing the package to pypi.org. I hoped it would be fixed with changing the order of the dependencies, which worked locally but again not after I had pushed the package to pypi.org.

So now I'm just going to resort to something that will definitely work, namely putting `llvmlite>0.36.0` as a hard dependency. It already is when you install `numba` through `umap-learn` and `hdbscan`, but now we make it a bit more explicit. 

I will delete the other releases that I hoped would fix the issues with `uv`, namely the `v0.17.2` and `v0.17.2.post1` releases. 
