### PR TITLE
ci: bump github actions versions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,8 +14,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
     # Ref: https://github.com/pre-commit/action
     - uses: pre-commit/action@v3.0.1
 
@@ -26,9 +28,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
# What does this PR do?

This PR bumps the GitHub Actions versions and via

```yaml
- uses: actions/setup-python@v6
  with:
    python-version: "3.13" # <-- added this part
```

removes the warning that was displayed in the GHA interface, e.g.

> lint
> The `python-version` input is not set. The version of Python currently in `PATH` will be used.

Ref: https://github.com/MaartenGr/BERTopic/actions/runs/18008728788

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
