### PR TITLE
ci: prefer action-pre-commit-uv for lint job

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,8 +18,8 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: "3.13"
-    # Ref: https://github.com/pre-commit/action
-    - uses: pre-commit/action@v3.0.1
+    # Ref: https://github.com/tox-dev/action-pre-commit-uv
+    - uses: tox-dev/action-pre-commit-uv@246b66536e366bb885f52d61983bf32f7c95e8b1 # v1.0.3
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What does this PR do?

This PR replaces the pre-commit/action GitHub action with tox-dev/action-pre-commit-uv, which utilizes uv to install pre-commit dependencies in their venvs. This speeds up the lint step (which was already fast).

This should be considered for merging, after #2427 is merged.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
