### PR TITLE
chore: remove obsolete `version_info` check

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -29,14 +29,7 @@ from scipy.sparse import csr_matrix
 from scipy.cluster import hierarchy as sch
 from importlib.util import find_spec
 
-# Typing
-import sys
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-from typing import List, Tuple, Union, Mapping, Any, Callable, Iterable, TYPE_CHECKING
+from typing import List, Tuple, Union, Mapping, Any, Callable, Iterable, TYPE_CHECKING, Literal
 
 # Plotting
 if find_spec("plotly") is None:


### PR DESCRIPTION
# What does this PR do?

This check is not required anymore, when the library requires Python 3.10+.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
