### PR TITLE
ci: switch to uv based project installation

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,5 +36,7 @@ jobs:
         activate-environment: "true"
     - name: Install dependencies (including test group)
       run: uv sync --extra test
+    - name: Display the project's dependency tree (including information on outdated packages)
+      run: uv tree --outdated
     - name: Run Checking Mechanisms
       run: make check


### PR DESCRIPTION
# What does this PR do?

This is a new version of #2082. The PR adds the `setup-uv` GHA to install uv and setup the python version from the matrix.

To still use the `make check`, I needed to add `activate-environment: true`, otherwise there is no pytest in PATH. Another solution would to call `uv run pytest` instead of `make check`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
