### PR TITLE
Update topic mapping when all documents match zero-shot topics

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -504,7 +504,7 @@ class BERTopic:
             documents = assigned_documents
             embeddings = assigned_embeddings
 
-             # Update topic sizes
+            # Update topic sizes
             self._update_topic_size(documents)
 
             # All documents matches zero-shot topics


### PR DESCRIPTION
Fix topic labels when all documents match zero-shot topics by updating the topic id mapping.

# What does this PR do?

When all documents match zero-shot topics, the labels for the topics are not set to the zero-shot topic name. 
This PR tries to fix this by updating the topic id/mapping and updating the topic sizes when there are no non-zero-shot topics.

Fixes #2447 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
