### PR TITLE
Make `SklearnEmbedder` return a dense array

### DIFF
--- a/bertopic/backend/_sklearn.py
+++ b/bertopic/backend/_sklearn.py
@@ -65,4 +65,4 @@ class SklearnEmbedder(BaseEmbedder):
         except NotFittedError:
             embeddings = self.pipe.fit_transform(documents)
 
-        return embeddings
+        return embeddings.toarray() if hasattr(embeddings, "toarray") else embeddings


### PR DESCRIPTION
As it stands, the `SKlearn.embed()` method returns a `scipy.sparse._csr.csr_matrix` object, which cannot be used directly with `np.average()` when computing topic embeddings. This is because `np.average()` attempts to cast the input using `np.asanyarray()`, resulting in an array with an empty shape.

This fix ensures that the output is always a dense NumPy array by calling the `.toarray()` method on the `csr_matrix` object before passing it to `np.average()`.