### PR TITLE
Update import path for Documents

### DIFF
--- a/bertopic/representation/_langchain.py
+++ b/bertopic/representation/_langchain.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from langchain.docstore.document import Document
+from langchain_core.documents import Document
 from scipy.sparse import csr_matrix
 from typing import Callable, Mapping, List, Tuple, Union
 


### PR DESCRIPTION
Fixes deprecated import path for Documents from langchain
See [here](https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain_classic/docstore/document.py)