### PR TITLE
Fix find_topics crash when search_term is a list of strings

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -1429,7 +1429,7 @@ class BERTopic:
         return topic_distributions, topic_token_distributions
 
     def find_topics(
-        self, search_term: str | None = None, image: str | None = None, top_n: int = 5
+        self, search_term: str | List[str] | None = None, image: str | None = None, top_n: int = 5
     ) -> Tuple[List[int], List[float]]:
         """Find topics most similar to a search_term.
 
@@ -1462,6 +1462,10 @@ class BERTopic:
 
         Note that the search query is typically more accurate if the
         search_term consists of a phrase or multiple words.
+
+        When ``search_term`` is a list of strings, each term is embedded
+        independently and the resulting vectors are averaged into a single
+        query embedding before computing similarity against topic embeddings.
         """
         if self.embedding_model is None:
             raise Exception("This method can only be used if you did not use custom embeddings.")
@@ -1471,7 +1475,11 @@ class BERTopic:
 
         # Extract search_term embeddings and compare with topic embeddings
         if search_term is not None:
-            search_embedding = self._extract_embeddings([search_term], method="word", verbose=False).flatten()
+            search_terms = [search_term] if isinstance(search_term, str) else list(search_term)
+            if not search_terms:
+                raise ValueError("search_term must be a non-empty string or list of strings.")
+            search_embeddings = self._extract_embeddings(search_terms, method="word", verbose=False)
+            search_embedding = np.mean(search_embeddings, axis=0).flatten()
         elif image is not None:
             search_embedding = self._extract_embeddings(
                 [None], images=[image], method="document", verbose=False

--- a/tests/test_representation/test_representations.py
+++ b/tests/test_representation/test_representations.py
@@ -182,3 +182,28 @@ def test_find_topics(model, request):
 
     assert np.mean(similarity) > 0.1
     assert len(similar_topics) > 0
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        ("kmeans_pca_topic_model"),
+        ("base_topic_model"),
+    ],
+)
+@pytest.mark.parametrize("search_term", [["car"], ["car", "vehicle"]])
+def test_find_topics_with_list(model, search_term, request):
+    """Regression test for #2392 / #2475: ``find_topics`` must accept a list
+    of search terms (including a single-element list) without crashing."""
+    topic_model = copy.deepcopy(request.getfixturevalue(model))
+    similar_topics, similarity = topic_model.find_topics(search_term)
+
+    assert len(similar_topics) > 0
+    assert len(similar_topics) == len(similarity)
+
+
+def test_find_topics_empty_list_raises(base_topic_model):
+    """An empty ``search_term`` list must raise instead of silently returning NaN similarities."""
+    topic_model = copy.deepcopy(base_topic_model)
+    with pytest.raises(ValueError, match="non-empty"):
+        topic_model.find_topics([])


### PR DESCRIPTION
# What does this PR do?

Fixes #2475
Fixes #2392

`BERTopic.find_topics(search_term)` crashes with `IndexError` when `search_term` is a single-element list, and silently misbehaves with two-element lists.

## Root cause

`find_topics` always wrapped `search_term` in an extra list before passing it to `_extract_embeddings`:

```python
search_embedding = self._extract_embeddings([search_term], method="word", verbose=False).flatten()
```

When the user passed a list, this produced a nested list (e.g. `[["car"]]`). `sentence-transformers`' tokenizer then interpreted the inner list as a text-pair, raising `IndexError` on `text_tuple[1]` for length-1 inputs and silently producing wrong embeddings for length-2 inputs (it appears to "work" for length ≥ 3 only by accident).

## Changes

- Resolve `search_term` to a flat list of strings: a string becomes a single-element list (preserving prior behavior); a list is passed through unchanged.
- Embed all terms and average the resulting vectors into a single query embedding before computing cosine similarity. Averaging is the standard centroid-search semantics for multi-term queries.
- Explicitly raise `ValueError` on empty input instead of silently returning `NaN` similarities from `np.mean` over zero rows.
- Widen the type hint to `str | List[str] | None` and document the list semantics in the docstring.

## Tests

- New `test_find_topics_with_list` parametrized over `["car"]` and `["car", "vehicle"]` across two fixture models — would have caught this bug.
- New `test_find_topics_empty_list_raises` covers the empty-list guard.
- Existing `test_find_topics` continues to pass (string input is unchanged).

All `find_topics` tests pass locally and `ruff check` / `ruff format --check` are clean.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes (if applicable)?
- [x] Did you write any new necessary tests?