### PR TITLE
Fix TopicMapper.add_new_topics inserting None placeholders that break model.save

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -5006,12 +5006,18 @@ class TopicMapper:
     def add_new_topics(self, mappings: Mapping[int, int]):
         """Add new row(s) of topic mappings.
 
+        New topics did not exist at earlier states, so the intermediate
+        history columns are backfilled with the topic's own ``key`` to
+        keep ``mappings_`` a homogeneous integer matrix. Without this,
+        ``None`` placeholders break ``model.save(serialization="safetensors")``
+        which casts the matrix to ``np.array(..., dtype=int)``.
+
         Arguments:
             mappings: The mappings to add
         """
         length = len(self.mappings_[0])
         for key, value in mappings.items():
-            to_append = [key] + ([None] * (length - 2)) + [value]
+            to_append = [key] * (length - 1) + [value]
             self.mappings_.append(to_append)
 
 

--- a/tests/test_bertopic.py
+++ b/tests/test_bertopic.py
@@ -1,6 +1,8 @@
 import copy
 import pytest
+import numpy as np
 from bertopic import BERTopic
+from bertopic._bertopic import TopicMapper
 import importlib.util
 
 
@@ -153,3 +155,34 @@ def test_full_model(model, documents, request):
     merged_model = BERTopic.merge_models([topic_model, topic_model1])
 
     assert len(merged_model.get_topic_info()) > len(topic_model.get_topic_info())
+
+
+def test_topic_mapper_add_new_topics_keeps_integer_matrix():
+    """Regression test for #2432: ``TopicMapper.add_new_topics`` must keep
+    ``mappings_`` as a homogeneous integer matrix.
+
+    Previously, ``add_new_topics`` inserted ``None`` placeholders for the
+    intermediate history columns, which broke ``model.save()`` because
+    ``_save_utils.save_topics`` casts the matrix to ``np.array(..., dtype=int)``.
+    """
+    mapper = TopicMapper(topics=[-1, 0, 1, 2])
+    # Simulate two prior reduce_topics calls so the matrix has more than 2
+    # columns (the buggy ``length - 2`` path is hidden when ``__init__``'s
+    # default 2-column shape is used).
+    for row in mapper.mappings_:
+        row.append(row[-1])
+        row.append(row[-1])
+    pre_existing = [list(row) for row in mapper.mappings_]
+
+    # New clusters discovered during partial_fit
+    mapper.add_new_topics({3: 2, 4: 3})
+
+    # The matrix must round-trip through ``np.array(..., dtype=int)``
+    # (mirrors what ``_save_utils.save_topics`` does).
+    matrix = np.array(mapper.mappings_, dtype=int)
+    # Pre-existing rows must be untouched.
+    assert mapper.mappings_[: len(pre_existing)] == pre_existing
+    # Original and current state of new rows must be preserved, and the
+    # intermediate history columns must be backfilled with the topic's own key.
+    assert (matrix[-2, :-1] == 3).all() and matrix[-2, -1] == 2
+    assert (matrix[-1, :-1] == 4).all() and matrix[-1, -1] == 3


### PR DESCRIPTION
# What does this PR do?

Fixes #2432

`BERTopic.save(serialization=\"safetensors\")` crashes with `TypeError` after `partial_fit` discovers new clusters.

## Root cause

`TopicMapper.add_new_topics` fills the intermediate history columns of new rows with `None` placeholders:

```python
to_append = [key] + ([None] * (length - 2)) + [value]
```

The `TopicMapper` class docstring documents `mappings_` as *\"A matrix indicating the mappings from one topic to another\"* — i.e., integers — and `_save_utils.save_topics` relies on that contract:

```python
\"topic_mapper\": np.array(model.topic_mapper_.mappings_, dtype=int).tolist(),
```

`None` is not castable to `int`, so the cast raises `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'` whenever a model is saved after `partial_fit` produced new clusters.

## Fix

Backfill the intermediate columns with the topic's own `key` instead of `None`, keeping `mappings_` a homogeneous integer matrix:

```python
to_append = [key] * (length - 1) + [value]
```

The fix is at the source rather than in `_save_utils.py`: the docstring promises an integer matrix, and the `None` placeholders were a contract violation. `get_mappings` only ever reads columns `[0, -1]` (or `[-3, -1]`) and never relied on the `None` sentinel for new rows, so callers are unaffected. Pre-existing rows added by `__init__` and `add_mappings` already contained only integers, so the new rows are now consistent with them.

## Tests

Adds `test_topic_mapper_add_new_topics_keeps_integer_matrix` in `tests/test_bertopic.py`. The test:

1. Builds a `TopicMapper` and simulates two prior \`reduce_topics\` calls so the matrix has more than 2 columns (otherwise the buggy `length - 2` path is hidden).
2. Calls `add_new_topics({3: 2, 4: 3})` to mimic new clusters being discovered during `partial_fit`.
3. Asserts the matrix round-trips through `np.array(..., dtype=int)` — exactly what `_save_utils.save_topics` does.
4. Asserts pre-existing rows are untouched.
5. Asserts the original (`key`) and current (`value`) state of new rows are preserved, and the intermediate columns are backfilled with the topic's own key.

`uv run pytest tests/test_bertopic.py` → 10 passed, 1 skipped (cuML), confirming nothing downstream (including `online_topic_model`'s `partial_fit` flow) depended on the `None` sentinel. `ruff check` and `ruff format --check` are clean.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes (if applicable)?
- [x] Did you write any new necessary tests?