### PR TITLE
Fix stop parameter check to allow explicit None value

### DIFF
--- a/bertopic/representation/_openai.py
+++ b/bertopic/representation/_openai.py
@@ -176,7 +176,7 @@ class OpenAI(BaseRepresentation):
             del self.generator_kwargs["model"]
         if self.generator_kwargs.get("prompt"):
             del self.generator_kwargs["prompt"]
-        if not self.generator_kwargs.get("stop"):
+        if "stop" not in self.generator_kwargs:
             self.generator_kwargs["stop"] = "\n"
 
     def extract_topics(


### PR DESCRIPTION
Previously, `not self.generator_kwargs.get("stop")` would overwrite a user-supplied `stop=None` (which disables the stop sequence). Use `"stop" not in` to only set the default when the key is absent.

Thinking models, at least gemma4:e2b in Ollama, will stop their reasoning chain on `\n` even if they shouldn't complete, so this gives a way to overwrite that

# What does this PR do?

checks if "stop" is a member of the `generator_kwargs` dict instead of just checking it as a boolean, as passing in `None` caused it to evaluate to `False` and it sets `stop` as `\n` anyway

Fixes #2481 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case. #2481 submitted alongside this PR
- [ ] Did you make sure to update the documentation with your changes (if applicable)? N/A
- [ ] Did you write any new necessary tests? N/A
