### PR TITLE
Update cuML install docs

### DIFF
--- a/docs/getting_started/clustering/clustering.md
+++ b/docs/getting_started/clustering/clustering.md
@@ -110,22 +110,17 @@ The great thing about using cuML's HDBSCAN implementation is that it supports ma
     However, it is still possible to calculate the topic-document probability matrix for the data on which the model was trained (i.e., `.fit` and `.fit_transform`).
 
 !!! note
-    To install cuML with BERTopic, run these commands:
+    To install cuML with BERTopic, run one of these commands:
 
     **For CUDA 12:**
     ```bash
-    !pip install cuml-cu12
-    !pip install bertopic
+    !pip install bertopic cuml-cu12
     ```
 
     **For CUDA 13:**
     ```bash
-    !pip install cuml-cu13
-    !pip install bertopic
+    !pip install bertopic cuml-cu13
     ```
-
-    !!! warning
-        Install cuML first, then BERTopic. Installing both in a single command can fail due to pip resolver limitations with CUDA runtime dependencies.
 
     **Note:** cuML is already installed on Google Colab.
 

--- a/docs/getting_started/dim_reduction/dim_reduction.md
+++ b/docs/getting_started/dim_reduction/dim_reduction.md
@@ -97,22 +97,17 @@ topic_model = BERTopic(umap_model=umap_model)
 ```
 
 !!! note
-    To install cuML with BERTopic, run these commands:
+    To install cuML with BERTopic, run one of these commands:
 
     **For CUDA 12:**
     ```bash
-    !pip install cuml-cu12
-    !pip install bertopic
+    !pip install bertopic cuml-cu12
     ```
 
     **For CUDA 13:**
     ```bash
-    !pip install cuml-cu13
-    !pip install bertopic
+    !pip install bertopic cuml-cu13
     ```
-
-    !!! warning
-        Install cuML first, then BERTopic. Installing both in a single command can fail due to pip resolver limitations with CUDA runtime dependencies.
 
     **Note:** cuML is already installed on Google Colab.
 

--- a/docs/getting_started/tips_and_tricks/tips_and_tricks.md
+++ b/docs/getting_started/tips_and_tricks/tips_and_tricks.md
@@ -181,22 +181,17 @@ embeddings = normalize(embeddings)
     However, it is still possible to calculate the topic-document probability matrix for the data on which the model was trained (i.e., `.fit` and `.fit_transform`).
 
 !!! note
-    To install cuML with BERTopic, run these commands:
+    To install cuML with BERTopic, run one of these commands:
 
     **For CUDA 12:**
     ```bash
-    !pip install cuml-cu12
-    !pip install bertopic
+    !pip install bertopic cuml-cu12
     ```
 
     **For CUDA 13:**
     ```bash
-    !pip install cuml-cu13
-    !pip install bertopic
+    !pip install bertopic cuml-cu13
     ```
-
-    !!! warning
-        Install cuML first, then BERTopic. Installing both in a single command can fail due to pip resolver limitations with CUDA runtime dependencies.
 
     **Note:** cuML is already installed on Google Colab.
 


### PR DESCRIPTION
# What does this PR do?

Updates the cuML installation examples to install BERTopic and the matching cuML package in a single command:

```bash
pip install bertopic cuml-cu12
```

and:

```bash
pip install bertopic cuml-cu13
```

This removes the previous warning that users should install cuML first because installing both packages together can fail due to pip resolver limitations. The original RAPIDS cuML issue (https://github.com/rapidsai/cuml/issues/7374) that motivated that workaround no longer reproduces with the current resolver/package set.

## Before submitting

- [x] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?