### PR TITLE
Add short-term fallback for models that do not support stop sequences

### DIFF
--- a/bertopic/representation/_openai.py
+++ b/bertopic/representation/_openai.py
@@ -225,7 +225,17 @@ class OpenAI(BaseRepresentation):
             if self.exponential_backoff:
                 response = chat_completions_with_backoff(self.client, **kwargs)
             else:
-                response = self.client.chat.completions.create(**kwargs)
+                try:
+                    response = self.client.chat.completions.create(**kwargs)
+                except openai.BadRequestError as e:
+                    if (
+                            "stop" in kwargs
+                            and "unsupported parameter" in str(e).lower()
+                            and "stop" in str(e).lower()
+                    ):
+                        kwargs.pop("stop", None)
+                        response = self.client.chat.completions.create(**kwargs)
+
 
             # Check whether content was actually generated
             # Addresses #1570 for potential issues with OpenAI's content filter
@@ -268,7 +278,21 @@ class OpenAI(BaseRepresentation):
 
 
 def chat_completions_with_backoff(client, **kwargs):
-    return retry_with_exponential_backoff(
+    create_with_backoff = retry_with_exponential_backoff(
         client.chat.completions.create,
         errors=(openai.RateLimitError,),
-    )(**kwargs)
+    )
+
+    try:
+        return create_with_backoff(**kwargs)
+    except openai.BadRequestError as e:
+        if (
+                "stop" in kwargs
+                and "unsupported parameter" in str(e).lower()
+                and "stop" in str(e).lower()
+        ):
+            kwargs = kwargs.copy()
+            kwargs.pop("stop", None)
+            return create_with_backoff(**kwargs)
+
+        raise

--- a/bertopic/representation/_openai.py
+++ b/bertopic/representation/_openai.py
@@ -228,14 +228,9 @@ class OpenAI(BaseRepresentation):
                 try:
                     response = self.client.chat.completions.create(**kwargs)
                 except openai.BadRequestError as e:
-                    if (
-                            "stop" in kwargs
-                            and "unsupported parameter" in str(e).lower()
-                            and "stop" in str(e).lower()
-                    ):
+                    if "stop" in kwargs and "unsupported parameter" in str(e).lower() and "stop" in str(e).lower():
                         kwargs.pop("stop", None)
                         response = self.client.chat.completions.create(**kwargs)
-
 
             # Check whether content was actually generated
             # Addresses #1570 for potential issues with OpenAI's content filter
@@ -282,15 +277,11 @@ def chat_completions_with_backoff(client, **kwargs):
         client.chat.completions.create,
         errors=(openai.RateLimitError,),
     )
-
     try:
         return create_with_backoff(**kwargs)
     except openai.BadRequestError as e:
-        if (
-                "stop" in kwargs
-                and "unsupported parameter" in str(e).lower()
-                and "stop" in str(e).lower()
-        ):
+        # Addresses an issue where
+        if "stop" in kwargs and "unsupported parameter" in str(e).lower() and "stop" in str(e).lower():
             kwargs = kwargs.copy()
             kwargs.pop("stop", None)
             return create_with_backoff(**kwargs)


### PR DESCRIPTION
# What does this PR do?

This PR addresses a couple of issues that point to the new OpenAI API not accepting the `stop` parameter with newer 5.0+ models (see: https://community.openai.com/t/stop-sequence-doesnt-work-with-gpt-5-1-chat-latest/1366918); however, the older, completions API  that BERTopic depends on still accepts this as a parameter. 

There are several ways to resolve this. 1. updgrade to the `respones` API, accept only newer models, 2. gate model queries by feature and 3. keep track of OpenAI models generally within BERTopic defensively.  This PR takes the "least surface area covered" approach to create a short-term patch, being aware that adding/removing specific API parameters might not be the most useful in the long-run. 

I believe the refactor mentioned here [would address as well ](https://github.com/MaartenGr/BERTopic/pull/2467), so feel free to close this current PR if it's already being addressed in other changes. 


Fixes # (issue)

https://github.com/MaartenGr/BERTopic/issues/2469
https://github.com/MaartenGr/BERTopic/pull/2482
https://github.com/MaartenGr/BERTopic/issues/2423



## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [X] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [X] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
