### PR TITLE
ci: set up automatic quarterly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# dependabot
+# Ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# ------------------------------------------------------------------------------
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  open-pull-requests-limit: 1
+  schedule:
+    interval: quarterly
+  groups:
+    github-actions:
+      patterns:
+      - '*'
+  cooldown:
+    default-days: 7
+- package-ecosystem: pre-commit
+  directory: /
+  open-pull-requests-limit: 1
+  schedule:
+    interval: quarterly
+  groups:
+    pre-commit:
+      patterns:
+      - '*'
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
# What does this PR do?

This PR sets up automatic quarterly dependency updates.

The dependabot config is set up to update the GitHub actions and the pre-commit hooks. The bot will generate a single PR per quarter to update all GHA and a second PR to update all pre-commit hooks.

This schedule is rather conservative and should not generate too much churn. What do you think?

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
