### PR TITLE
ci: display only direct dependencies of bertopic in the tree

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,6 +37,6 @@ jobs:
     - name: Install dependencies (including test group)
       run: uv sync --extra test
     - name: Display the project's dependency tree (including information on outdated packages)
-      run: uv tree --outdated
+      run: uv tree --outdated --depth=1
     - name: Run Checking Mechanisms
       run: make check


### PR DESCRIPTION
# What does this PR do?

This PR add the `--depth 1` flag to the uv tree command in CI. This way there is only direct dependencies of BERTopic displayed which makes scanning them visually a little easier. What do you think?

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
