### PR TITLE
ci: fix zizmor findings

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,11 +10,15 @@ on:
     - master
     - dev
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@v6
       with:
         python-version: "3.13"
@@ -29,6 +33,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Install latest version of uv and set up Python ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@v7
       with:


### PR DESCRIPTION
# What does this PR do?

This PR hardens the CI security a little bit, by running zizmor on the workflow file.

I fixed the following warnings:
- warning[excessive-permissions]: overly broad permissions
- help[artipacked]: credential persistence through GitHub Actions artifacts

Do you additionally want to pin the gha versions, as recommended by zizmor?

- error[unpinned-uses]: unpinned action reference, https://docs.zizmor.sh/audits/#unpinned-uses

Ref: https://docs.zizmor.sh

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes (if applicable)?
- [ ] Did you write any new necessary tests?
