### PR TITLE
Fix TypeError in save() when TopicMapper.mappings_ contains None (#2432)

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -5011,7 +5011,12 @@ class TopicMapper:
         """
         length = len(self.mappings_[0])
         for key, value in mappings.items():
-            to_append = [key] + ([None] * (length - 2)) + [value]
+            # A brand-new topic maps from itself in all prior states. Using ``key`` for the
+            # intermediate columns (instead of ``None``) keeps ``mappings_`` a homogeneous
+            # integer matrix, which is required by ``save`` (see #2432). ``None`` would break
+            # ``np.array(mappings_, dtype=int)`` once the matrix has more than two columns
+            # (e.g. after repeated ``partial_fit`` calls).
+            to_append = [key] * (length - 1) + [value]
             self.mappings_.append(to_append)
 
 

--- a/tests/test_bertopic.py
+++ b/tests/test_bertopic.py
@@ -1,6 +1,8 @@
 import copy
 import pytest
+import numpy as np
 from bertopic import BERTopic
+from bertopic._bertopic import TopicMapper
 import importlib.util
 
 
@@ -153,3 +155,36 @@ def test_full_model(model, documents, request):
     merged_model = BERTopic.merge_models([topic_model, topic_model1])
 
     assert len(merged_model.get_topic_info()) > len(topic_model.get_topic_info())
+
+
+def test_topic_mapper_add_new_topics_keeps_integer_matrix():
+    """Regression test for #2432.
+
+    ``TopicMapper.add_new_topics`` used to pad the intermediate columns of a new
+    row with ``None``. Once the mapping matrix had more than two columns (which
+    happens after repeated ``partial_fit`` calls), this made ``mappings_`` a
+    non-homogeneous matrix and broke ``save`` with a ``TypeError`` when it
+    converted the mappings via ``np.array(mappings_, dtype=int)``.
+    """
+    mapper = TopicMapper([-1, 0, 1, 2])
+
+    # Simulate additional topic states, as produced by repeated ``partial_fit``
+    # calls, so that the mapping matrix has more than two columns.
+    for row in mapper.mappings_:
+        row.append(row[-1])
+    assert len(mapper.mappings_[0]) == 3
+
+    original_rows = copy.deepcopy(mapper.mappings_)
+
+    # Adding new topics must not introduce ``None`` values into the matrix.
+    mapper.add_new_topics({3: 2, 4: 3})
+
+    # ``save`` performs exactly this conversion; it must not raise.
+    np.array(mapper.mappings_, dtype=int)
+
+    # Pre-existing rows must round-trip unchanged.
+    assert mapper.mappings_[: len(original_rows)] == original_rows
+
+    # New topics map from themselves in all prior states and to their target.
+    assert mapper.mappings_[-2] == [3, 3, 2]
+    assert mapper.mappings_[-1] == [4, 4, 3]


### PR DESCRIPTION
# What does this PR do?

Fixes #2432

## Root cause

`TopicMapper.add_new_topics` pads the intermediate columns of a newly added row with `None`:

```python
to_append = [key] + ([None] * (length - 2)) + [value]
```

As long as the mapping matrix has only two columns this is harmless (`length - 2 == 0`, so no `None` is inserted). However, once the matrix grows past two columns — which happens after repeated `partial_fit` calls — every new topic row gets one or more `None` placeholders. `mappings_` is then no longer a homogeneous integer matrix.

Saving the model later calls `_save_utils.save_topics`, which converts the whole table with:

```python
np.array(model.topic_mapper_.mappings_, dtype=int)
```

and this raises `TypeError: int() argument must be ... not 'NoneType'`, exactly as reported in the issue's `partial_fit` + `save(serialization="safetensors")` reproduction.

## Fix

A brand-new topic maps from itself in all prior states, so the intermediate columns should hold the topic id rather than `None`:

```python
to_append = [key] * (length - 1) + [value]
```

This keeps `mappings_` a homogeneous integer matrix so `save()` succeeds, and it is a no-op for the common two-column case (`[key] * 1 + [value]` == `[key, value]`, identical to the previous output). On load, `mappings_` is assigned back verbatim, so the rows round-trip unchanged.

## Test

Adds `test_topic_mapper_add_new_topics_keeps_integer_matrix` in `tests/test_bertopic.py`. It builds a `TopicMapper`, widens the matrix past two columns to mimic repeated `partial_fit` states, calls `add_new_topics`, and asserts that `np.array(mappings_, dtype=int)` no longer raises, that pre-existing rows are unchanged, and that the new rows are homogeneous integers. The test is lightweight and does not train a model. It fails on the previous implementation (with the `TypeError` from the issue) and passes with this change.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? See #2432.
- [ ] Did you make sure to update the documentation with your changes (if applicable)? Not applicable.
- [x] Did you write any new necessary tests?