### PR TITLE
Handle None content in OpenAI representation (#2353)

### DIFF
--- a/bertopic/representation/_openai.py
+++ b/bertopic/representation/_openai.py
@@ -229,9 +229,12 @@ class OpenAI(BaseRepresentation):
 
             # Check whether content was actually generated
             # Addresses #1570 for potential issues with OpenAI's content filter
-            # Addresses #2176 for potential issues when openAI returns a None type object
-            if response and hasattr(response.choices[0].message, "content"):
-                label = response.choices[0].message.content.strip().replace("topic: ", "")
+            # Addresses #2176 and #2353 for potential issues when OpenAI returns a None
+            # type object. The ``content`` field is always present but can be ``None``
+            # (e.g. when ``finish_reason='content_filter'``), so ``hasattr`` is not enough.
+            content = response.choices[0].message.content if response else None
+            if content is not None:
+                label = content.strip().replace("topic: ", "")
             else:
                 label = "No label returned"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ spacy = [
     "spacy>=3.0.1",
 ]
 test = [
+    "openai>=1.0.0",
     "pytest>=5.4.3",
     "pytest-cov>=2.6.1",
     "ruff~=0.14.0",

--- a/tests/test_representation/test_openai.py
+++ b/tests/test_representation/test_openai.py
@@ -1,0 +1,67 @@
+"""Unit tests for the OpenAI representation model."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+# The OpenAI representation imports the ``openai`` package at module load time,
+# so skip these tests entirely when it is not installed.
+pytest.importorskip("openai")
+
+from bertopic.representation._openai import OpenAI
+
+
+def _make_client(content):
+    """Build a mock OpenAI client whose chat completion returns ``content``."""
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+
+    client = MagicMock()
+    client.chat.completions.create.return_value = response
+    return client
+
+
+def _make_topic_model():
+    """Build a mock topic model returning a single topic with representative docs."""
+    topic_model = MagicMock()
+    topic_model.verbose = False
+    topic_model._extract_representative_docs.return_value = (
+        {0: ["A document about pets.", "Another document about pets."]},
+        None,
+        None,
+        None,
+    )
+    return topic_model
+
+
+def test_openai_extract_topics_handles_none_content():
+    """Regression test for #2353.
+
+    When OpenAI returns a message whose ``content`` is ``None`` (for example when the
+    response is blocked by the content filter and ``finish_reason='content_filter'``),
+    the ``content`` field is still present, so the previous ``hasattr`` guard passed
+    and ``None.strip()`` raised ``AttributeError``. The representation must instead
+    fall back to a placeholder label.
+    """
+    representation = OpenAI(_make_client(content=None))
+
+    updated_topics = representation.extract_topics(
+        _make_topic_model(), documents=None, c_tf_idf=None, topics={0: [("pets", 0.9)]}
+    )
+
+    assert updated_topics == {0: [("No label returned", 1)]}
+
+
+def test_openai_extract_topics_strips_normal_content():
+    """A normal (non-None) response is stripped and the ``topic: `` prefix removed."""
+    representation = OpenAI(_make_client(content="topic: Pets\n"))
+
+    updated_topics = representation.extract_topics(
+        _make_topic_model(), documents=None, c_tf_idf=None, topics={0: [("pets", 0.9)]}
+    )
+
+    assert updated_topics == {0: [("Pets", 1)]}


### PR DESCRIPTION
# What does this PR do?

Fixes #2353

## Root cause

In `bertopic/representation/_openai.py`, the generated label was guarded with:

```python
if response and hasattr(response.choices[0].message, "content"):
    label = response.choices[0].message.content.strip().replace("topic: ", "")
else:
    label = "No label returned"
```

`content` is always present as a field on the message, so `hasattr(...)` is always `True`. When OpenAI/AzureOpenAI blocks a response via the content filter, it returns `finish_reason='content_filter'` with `content=None`. The guard passes and `None.strip()` raises:

```
AttributeError: 'NoneType' object has no attribute 'strip'
```

as reported in the issue traceback (at the `.content.strip()` line).

## Fix

Read `content` first and check it explicitly against `None`:

```python
content = response.choices[0].message.content if response else None
if content is not None:
    label = content.strip().replace("topic: ", "")
else:
    label = "No label returned"
```

This reuses the existing `"No label returned"` placeholder and keeps behavior identical for normal (non-`None`) responses. There is a single chat-completions code path in this file, so no other call site needs changing.

## Test

Adds `tests/test_representation/test_openai.py` with two lightweight unit tests that call `extract_topics` directly against a mocked OpenAI client (no model training):

- `content=None` returns `{0: [("No label returned", 1)]}` and does not raise (this fails on the previous implementation with the `AttributeError` from the issue).
- normal content `"topic: Pets\n"` is stripped and the `topic: ` prefix removed, yielding `{0: [("Pets", 1)]}`.

The module imports `openai` at load time, so the tests use `pytest.importorskip("openai")`, and `openai>=1.0.0` is added to the `test` extra so they run under CI's `uv sync --extra test`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if yes, ignore all other checks!).
- [x] Did you read the [contributor guideline](https://github.com/MaartenGr/BERTopic/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? See #2353.
- [ ] Did you make sure to update the documentation with your changes (if applicable)? Not applicable.
- [x] Did you write any new necessary tests?